### PR TITLE
Add support for TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: rust
+branches: 
+  only:
+  - master
+
+cache: cargo
+
+matrix:
+  fast_finish: false
+  include:
+  - rust: nightly
+
+script:
+  - cargo check
+  - cargo build --verbose --all
+  - cargo test --verbose --all


### PR DESCRIPTION
- Only added support on nightly builds since
some imports of `bulletproofs` dalek crate
need to make usage of nightly features.
- `master` is the only branch tracked.
- On every commit/PR/MR, build and tests will
be run.