### PR TITLE
Implement Merkle-Tree Level hashing & kelvin traits inclusion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,8 @@ edition = "2018"
 
 [dependencies]
 dusk-bls12_381 = "0.1"
-merlin = "2"
+kelvin = "0.13.0"
+kelvin-hamt = "0.10.0"
 lazy_static = "1.3.0"
 hades252 = { git = "https://github.com/dusk-network/hades252", version = "0.5.0" }
 dusk-plonk = {version = "0.1", features = ["trace-print"]}
@@ -17,6 +18,7 @@ dusk-plonk = {version = "0.1", features = ["trace-print"]}
 rand = "0.7"
 rand_core = "0.5"
 criterion = "0.3"
+merlin = "2"
 
 [profile.dev]
 opt-level = 3

--- a/src/hashing_utils/mod.rs
+++ b/src/hashing_utils/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod scalar_storage;

--- a/src/hashing_utils/mod.rs
+++ b/src/hashing_utils/mod.rs
@@ -1,1 +1,2 @@
+pub(crate) mod poseidon_annotation;
 pub(crate) mod scalar_storage;

--- a/src/hashing_utils/poseidon_annotation.rs
+++ b/src/hashing_utils/poseidon_annotation.rs
@@ -1,0 +1,92 @@
+//! Helpers for kelvin hashing & storing trait implementations
+use super::scalar_storage::StorageScalar;
+use crate::merkle_lvl_hash::hash;
+use crate::ARITY;
+use dusk_bls12_381::Scalar;
+use kelvin::{ByteHash, Combine, Content, ErasedAnnotation, Sink, Source, KV};
+use std::borrow::Borrow;
+use std::io;
+use std::io::Read;
+
+#[derive(Clone, Debug)]
+/// Wrapping struct that defines used to implement over it
+/// the hashing logic that Kelvin needs in order to provide
+/// Merkle Paths as `Branch` using Poseidon as the main Hasing
+/// algorithm.
+pub struct PoseidonAnnotation(pub StorageScalar);
+
+impl Borrow<StorageScalar> for PoseidonAnnotation {
+    fn borrow(&self) -> &StorageScalar {
+        &self.0
+    }
+}
+
+impl<A> Combine<A> for PoseidonAnnotation {
+    /// This implements the logic that Kelvin needs in order to know how to
+    /// hash an entire merkle tree level.
+    ///
+    /// It includes the generation of the bitflags logic inside of it.
+    fn combine<E>(elements: &[E]) -> Option<Self>
+    where
+        A: Borrow<Self> + Clone,
+        E: ErasedAnnotation<A>,
+    {
+        let mut leaves: [Option<Scalar>; ARITY] = [None; ARITY];
+        elements
+            .iter()
+            .zip(leaves.iter_mut())
+            .for_each(|(element, leave)| {
+                match element.annotation() {
+                    Some(annotation) => {
+                        let h: &PoseidonAnnotation = (*annotation).borrow();
+                        *leave = Some(h.inner().0);
+                    }
+                    None => *leave = None,
+                };
+            });
+        let res = hash::merkle_level_hash(&leaves);
+        Some(PoseidonAnnotation(StorageScalar(res)))
+    }
+}
+
+impl<H> Content<H> for PoseidonAnnotation
+where
+    H: ByteHash,
+{
+    fn persist(&mut self, sink: &mut Sink<H>) -> io::Result<()> {
+        self.inner().0.to_bytes().persist(sink)
+    }
+    fn restore(source: &mut Source<H>) -> io::Result<Self> {
+        let mut bytes = [0u8; 32];
+        for (idx, byte) in source.bytes().enumerate() {
+            bytes[idx] = byte.unwrap();
+        }
+        Ok(PoseidonAnnotation(StorageScalar(
+            Scalar::from_bytes(&bytes).unwrap(),
+        )))
+    }
+}
+
+impl<T> From<&KV<T, StorageScalar>> for PoseidonAnnotation {
+    fn from(kv: &KV<T, StorageScalar>) -> Self {
+        PoseidonAnnotation(kv.val.clone())
+    }
+}
+
+impl From<&Scalar> for PoseidonAnnotation {
+    fn from(scalar: &Scalar) -> Self {
+        PoseidonAnnotation(StorageScalar(scalar.clone()))
+    }
+}
+
+impl From<&StorageScalar> for PoseidonAnnotation {
+    fn from(stor_scalar: &StorageScalar) -> Self {
+        PoseidonAnnotation(stor_scalar.clone())
+    }
+}
+
+impl PoseidonAnnotation {
+    fn inner(&self) -> StorageScalar {
+        self.0.clone()
+    }
+}

--- a/src/hashing_utils/poseidon_annotation.rs
+++ b/src/hashing_utils/poseidon_annotation.rs
@@ -58,12 +58,15 @@ where
     }
     fn restore(source: &mut Source<H>) -> io::Result<Self> {
         let mut bytes = [0u8; 32];
-        for (idx, byte) in source.bytes().enumerate() {
-            bytes[idx] = byte.unwrap();
-        }
-        Ok(PoseidonAnnotation(StorageScalar(
-            Scalar::from_bytes(&bytes).unwrap(),
-        )))
+        // The solution with iterators is a way more messy.
+        // See: https://doc.rust-lang.org/stable/rust-by-example/error/iter_result.html
+        source.read_exact(&mut bytes)?;
+        let might_be_scalar = Scalar::from_bytes(&bytes);
+        if might_be_scalar.is_none().unwrap_u8() == 1u8 {
+            return Err(std::io::ErrorKind::InvalidData.into());
+        };
+        // Now it's safe to unwrap.
+        return Ok(PoseidonAnnotation(StorageScalar(might_be_scalar.unwrap())));
     }
 }
 

--- a/src/hashing_utils/scalar_storage.rs
+++ b/src/hashing_utils/scalar_storage.rs
@@ -1,0 +1,52 @@
+//! This module defines a Wrap-up over the dusk-bls12_381 to define it's kelvin
+//! storage traits
+
+use dusk_bls12_381::Scalar;
+use kelvin::{ByteHash, Content, Sink, Source};
+use std::borrow::Borrow;
+use std::io;
+use std::io::Read;
+
+#[derive(Debug, Clone)]
+/// This struct is a Wrapper type over the bls12-381 `Scalar` which has implemented
+/// inside the logic to allows `Kelvin` Merkle Trees understand how to store `Scalar`s
+/// inside of them leaves.
+///
+/// This Struct is the one that we will use inside of our SmartContract storage logic to
+/// encode/compress all of our Data Structures data into a single `Scalar`.
+pub struct StorageScalar(pub Scalar);
+
+impl Default for StorageScalar {
+    fn default() -> Self {
+        StorageScalar(Scalar::default())
+    }
+}
+
+impl Borrow<Scalar> for StorageScalar {
+    fn borrow(&self) -> &Scalar {
+        &self.0
+    }
+}
+
+impl Into<Scalar> for StorageScalar {
+    fn into(self) -> Scalar {
+        self.0
+    }
+}
+
+// Implements logic for storing Scalar inside of kelvin
+impl<H> Content<H> for StorageScalar
+where
+    H: ByteHash,
+{
+    fn persist(&mut self, sink: &mut Sink<H>) -> io::Result<()> {
+        self.0.to_bytes().persist(sink)
+    }
+    fn restore(source: &mut Source<H>) -> io::Result<Self> {
+        let mut bytes = [0u8; 32];
+        for (idx, byte) in source.bytes().enumerate() {
+            bytes[idx] = byte.unwrap();
+        }
+        Ok(StorageScalar(Scalar::from_bytes(&bytes).unwrap()))
+    }
+}

--- a/src/hashing_utils/scalar_storage.rs
+++ b/src/hashing_utils/scalar_storage.rs
@@ -28,6 +28,10 @@ impl Borrow<Scalar> for StorageScalar {
     }
 }
 
+// This is implemented since `PoseidonAnnotation` wraps up over `StorageScalar`.
+// Therefore, in rust to get the interal `Scalar` from the annotation you'll
+// need to call `annotation.0.0` and this is not valid.
+// This trait impl solves the problem.
 impl Into<Scalar> for StorageScalar {
     fn into(self) -> Scalar {
         self.0
@@ -44,8 +48,10 @@ where
     }
     fn restore(source: &mut Source<H>) -> io::Result<Self> {
         let mut bytes = [0u8; 32];
-        for (idx, byte) in source.bytes().enumerate() {
-            bytes[idx] = byte.unwrap();
+        // The solution with iterators is a way more messy.
+        // See: https://doc.rust-lang.org/stable/rust-by-example/error/iter_result.html
+        for (src, dest) in source.bytes().zip(bytes.iter_mut()) {
+            *dest = src?
         }
         Ok(StorageScalar(Scalar::from_bytes(&bytes).unwrap()))
     }

--- a/src/hashing_utils/scalar_storage.rs
+++ b/src/hashing_utils/scalar_storage.rs
@@ -50,9 +50,12 @@ where
         let mut bytes = [0u8; 32];
         // The solution with iterators is a way more messy.
         // See: https://doc.rust-lang.org/stable/rust-by-example/error/iter_result.html
-        for (src, dest) in source.bytes().zip(bytes.iter_mut()) {
-            *dest = src?
-        }
-        Ok(StorageScalar(Scalar::from_bytes(&bytes).unwrap()))
+        source.read_exact(&mut bytes)?;
+        let might_be_scalar = Scalar::from_bytes(&bytes);
+        if might_be_scalar.is_none().unwrap_u8() == 1u8 {
+            return Err(std::io::ErrorKind::InvalidData.into());
+        };
+        // Now it's safe to unwrap.
+        return Ok(StorageScalar(might_be_scalar.unwrap()));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,3 +15,24 @@ pub mod sponge;
 /// This is due to the fact that actually we rely in Hades252 crate
 /// which `WIDTH` parameter is 5.
 pub const ARITY: usize = hades252::WIDTH - 1;
+
+/// Wrapping struct that defines used to implement over it
+/// the hashing logic that Kelvin needs in order to provide
+/// Merkle Paths as `Branch` using Poseidon as the main Hasing
+/// algorithm.
+///
+pub use hashing_utils::poseidon_annotation::PoseidonAnnotation;
+
+/// This struct is a Wrapper type over the bls12-381 `Scalar` which has implemented
+/// inside the logic to allows `Kelvin` Merkle Trees understand how to store `Scalar`s
+/// inside of them leaves.
+///
+/// This Struct is the one that we will use inside of our SmartContract storage logic to
+/// encode/compress all of our Data Structures data into a single `Scalar`.
+pub use hashing_utils::scalar_storage::StorageScalar;
+
+/// This structures should only be used if you want to elaborate custom Merkle-Tree proofs.
+///
+/// If that's not the case, you should just call the `merkle_proof` with the required fields
+/// and forget about this structures since they're properly handled internally.
+pub use merkle_proof::{PoseidonBranch, PoseidonLevel};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,15 @@
 //! Reference implementation for the Poseidon Sponge function
 #![deny(missing_docs)]
 
-///
+/// Reference implementation for the Poseidon Merkle hash function
 pub mod merkle_lvl_hash;
-/// Reference implementation for the Poseidon Sponge function
+/// Reference implementation for the gadget that builds a merkle opening proof
+pub mod merkle_proof;
+/// Reference implementation for the Poseidon Sponge hash function
 pub mod sponge;
+
+/// Maximum arity supported for trees.
+///
+/// This is due to the fact that actually we rely in Hades252 crate
+/// which `WIDTH` parameter is 5.
+pub const ARITY: usize = hades252::WIDTH - 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 //! Reference implementation for the Poseidon Sponge function
 #![deny(missing_docs)]
 
+///
+pub mod merkle_lvl_hash;
 /// Reference implementation for the Poseidon Sponge function
 pub mod sponge;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 //! Reference implementation for the Poseidon Sponge function
 #![deny(missing_docs)]
 
+///
+pub mod hashing_utils;
 /// Reference implementation for the Poseidon Merkle hash function
 pub mod merkle_lvl_hash;
 /// Reference implementation for the gadget that builds a merkle opening proof

--- a/src/merkle_lvl_hash/hash.rs
+++ b/src/merkle_lvl_hash/hash.rs
@@ -1,0 +1,198 @@
+//! The Merkle Level Hashing is a technique that Poseidon is optimized-by-design
+//! to perform.
+//!
+//! This technique allows us to perform hashes of an entire Merkle Tree using
+//! `Hades252` as backend.
+//! The technique requires the computation of a `bitflags` element which is always
+//! positioned as the first item of the level when we hash it, and it basically generated
+//! in respect of the presence or absence of a leaf in the tree level.
+//! This allows to prevent hashing collitions.
+//!
+//! At the moment, this library is designed and optimized to work only with trees of `ARITY`
+//! up to 4. **That means that trees with a bigger ARITY SHOULD NEVER be used with this lib.**
+//!
+//! The module contains the implementation of 4 variants of the same algorithm to support the
+//! majority of the configurations that the user may need:
+//! - Scalar backend for hashing Merkle Tree levels outside of ZK-Circuits whith two variants:
+//! One of them computes the bitflags item while the other assumes that it has already been
+//! computed and placed in the first Level position.
+//!
+//! - `dusk_plonk::Variable` backend for hashing Merkle Tree levels inside of ZK-Circuits,
+//!  specifically, PLONK circuits. This implementation comes also whith two variants;
+//! One of them computes the bitflags item while the other assumes that it has already been
+//! computed and placed in the first Level position.
+use crate::merkle_proof::poseidon_branch::PoseidonLevel;
+use crate::ARITY;
+use dusk_bls12_381::Scalar;
+use dusk_plonk::constraint_system::{StandardComposer, Variable};
+use hades252::strategies::*;
+use hades252::WIDTH;
+
+/// The `poseidon_hash` function takes a Merkle Tree Level with up to `ARITY`
+/// leaves and applies the poseidon hash, using the `hades252::ScalarStragegy` and
+/// computing the corresponding bitflags.
+#[allow(dead_code)]
+pub fn merkle_level_hash(leaves: &[Option<Scalar>]) -> Scalar {
+    let mut strategy = ScalarStrategy::new();
+    let mut accum = 0u64;
+    let mut res = [Scalar::zero(); WIDTH];
+    leaves
+        .iter()
+        .enumerate()
+        .zip(res.iter_mut().skip(1))
+        .for_each(|((idx, l), r)| match l {
+            Some(scalar) => {
+                *r = *scalar;
+                accum += 1u64 << ((ARITY - 1) - idx);
+            }
+            None => *r = Scalar::zero(),
+        });
+    // Set bitflags as first element.
+    res[0] = Scalar::from(accum);
+    strategy.perm(&mut res);
+    res[1]
+}
+
+/// The `poseidon_hash` function takes a `PoseidonLevel` which has already computed
+/// the bitflags and hashes it returning the resulting `Scalar`.
+pub(crate) fn merkle_level_hash_without_bitflags(poseidon_level: &PoseidonLevel) -> Scalar {
+    let mut strategy = ScalarStrategy::new();
+    let mut res = poseidon_level.leaves.clone();
+    strategy.perm(&mut res);
+    res[1]
+}
+
+/// The `poseidon_hash` function takes a Merkle Tree level with up to `ARITY`
+/// leaves and applies the poseidon hash, using the `hades252::GadgetStragegy` and
+/// computing the corresponding bitflags.
+#[allow(dead_code)]
+pub fn merkle_level_hash_gadget(
+    composer: &mut StandardComposer,
+    leaves: &[Option<Variable>],
+) -> Variable {
+    let mut accum = 0u64;
+    let mut res = [composer.zero_var; WIDTH];
+    leaves
+        .iter()
+        .zip(res.iter_mut().skip(1))
+        .enumerate()
+        .for_each(|(idx, (l, r))| match l {
+            Some(var) => {
+                *r = *var;
+                accum += 1u64 << ((ARITY - 1) - idx);
+            }
+            None => *r = composer.zero_var,
+        });
+    // Set bitflags as first element.
+    res[0] = composer.add_input(Scalar::from(accum));
+    let mut strategy = GadgetStrategy::new(composer);
+    strategy.perm(&mut res);
+    res[1]
+}
+
+/// The `poseidon_hash` function takes a Merkle Tree level which has
+/// already computed the bitflags term and applies the poseidon hash,
+/// using the `hades252::GadgetStragegy` returning the resulting `Variable`.
+pub(crate) fn merkle_level_hash_gadget_without_bitflags(
+    composer: &mut StandardComposer,
+    leaves: &mut [Variable; WIDTH],
+) -> Variable {
+    let mut strategy = GadgetStrategy::new(composer);
+    strategy.perm(leaves);
+    leaves[1]
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use dusk_plonk::commitment_scheme::kzg10::PublicParameters;
+    use dusk_plonk::fft::EvaluationDomain;
+    use merlin::Transcript;
+
+    fn gen_random_merkle_level() -> ([Option<Scalar>; ARITY], Scalar) {
+        let mut input = [Some(Scalar::zero()); ARITY];
+        input
+            .iter_mut()
+            .for_each(|s| *s = Some(Scalar::random(&mut rand::thread_rng())));
+        // Set to None a leave
+        input[2] = None;
+        // Compute the level hash
+        let output = merkle_level_hash(&input);
+        (input, output)
+    }
+
+    #[test]
+    fn test_merkle_level_bitflags() {
+        // Get the inputs and the merkle level hash output
+        let (leaves, expected_hash) = gen_random_merkle_level();
+
+        // According to the gen_random_merkle_level, our level will have
+        // the following: [Some(leaf), Some(leaf), None, Some(leaf)]
+        //
+        // This means having a bitflags = 1101 = Scalar::from(13u64).
+        // So we will compute the hash without the bitflags requirement
+        // already providing it. And it should match the expected one.
+        let level = PoseidonLevel {
+            leaves: [
+                // Set the bitflags we already expect
+                Scalar::from(13u64),
+                // Set the rest of the values as the leaf or zero
+                leaves[0].unwrap_or(Scalar::zero()),
+                leaves[1].unwrap_or(Scalar::zero()),
+                leaves[2].unwrap_or(Scalar::zero()),
+                leaves[3].unwrap_or(Scalar::zero()),
+            ],
+            // We don't care about this in this specific functionallity test.
+            offset: 0usize,
+        };
+        let obtained_hash = merkle_level_hash_without_bitflags(&level);
+
+        assert_eq!(obtained_hash, expected_hash);
+    }
+
+    #[test]
+    fn test_merkle_level_gadget_bitflags() {
+        // Gen Public Params and Keys.
+        let pub_params = PublicParameters::setup(1 << 12, &mut rand::thread_rng()).unwrap();
+        let (ck, vk) = pub_params.trim(1 << 11).unwrap();
+        let mut transcript = Transcript::new(b"Test");
+
+        // Generate input merkle level
+        let (level_sacalars, expected_hash) = gen_random_merkle_level();
+
+        // Generate a composer
+        let mut composer = StandardComposer::new();
+
+        // Get the leafs as Variable and add the bitflags that
+        // According to the gen_random_merkle_level, our level will have
+        // the following: [Some(leaf), Some(leaf), None, Some(leaf)]
+        //
+        // This means having a bitflags = 1101 = Variable(Scalar::from(13u64)).
+        // So we will compute the hash without the bitflags requirement
+        // already providing it. And it should match the expected one.
+        let mut leaves = [
+            // Set the bitflags we already expect
+            composer.add_input(Scalar::from(13u64)),
+            // Set the rest of the values as the leaf or zero
+            composer.add_input(level_sacalars[0].unwrap_or(Scalar::zero())),
+            composer.add_input(level_sacalars[1].unwrap_or(Scalar::zero())),
+            composer.add_input(level_sacalars[2].unwrap_or(Scalar::zero())),
+            composer.add_input(level_sacalars[3].unwrap_or(Scalar::zero())),
+        ];
+
+        let obtained_hash = merkle_level_hash_gadget_without_bitflags(&mut composer, &mut leaves);
+        let expected_hash = composer.add_input(expected_hash);
+        // Check with an assert_equal gate that the hash computed is indeed correct.
+        composer.assert_equal(obtained_hash, expected_hash);
+
+        // Since we don't use all of the wires, we set some dummy constraints to avoid Committing
+        // to zero polynomials.
+        composer.add_dummy_constraints();
+
+        let prep_circ =
+            composer.preprocess(&ck, &mut transcript, &EvaluationDomain::new(2048).unwrap());
+
+        let proof = composer.prove(&ck, &prep_circ, &mut transcript.clone());
+        assert!(proof.verify(&prep_circ, &mut transcript, &vk, &vec![Scalar::zero()]));
+    }
+}

--- a/src/merkle_lvl_hash/mod.rs
+++ b/src/merkle_lvl_hash/mod.rs
@@ -1,0 +1,2 @@
+//! Poseidon hash implementation
+pub(crate) mod hash;

--- a/src/merkle_proof/mod.rs
+++ b/src/merkle_proof/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod poseidon_branch;

--- a/src/merkle_proof/mod.rs
+++ b/src/merkle_proof/mod.rs
@@ -1,1 +1,2 @@
 pub(crate) mod poseidon_branch;
+pub use poseidon_branch::{PoseidonBranch, PoseidonLevel};

--- a/src/merkle_proof/poseidon_branch.rs
+++ b/src/merkle_proof/poseidon_branch.rs
@@ -1,0 +1,134 @@
+//! Definitions of the merkle tree structure seen in Poseidon.
+
+use crate::hashing_utils::scalar_storage::StorageScalar;
+use crate::ARITY;
+use dusk_bls12_381::Scalar;
+use hades252::WIDTH;
+use kelvin::{Branch, ByteHash, Compound};
+use std::borrow::Borrow;
+
+/// The `Poseidon` structure will accept a number of inputs equal to the arity.
+///
+/// The levels are ordered so the first element of `levels` is actually the bottom
+/// level of the Kelvin tree.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PoseidonBranch {
+    /// Root of the Merkle Tree
+    pub root: Scalar,
+    /// Levels of the MerkleTree with it's corresponding leaves and offset.
+    pub levels: Vec<PoseidonLevel>,
+}
+
+/// Provides a conversion between Branch and PoseidonBranch.
+///
+/// We extract the data from the `Branch` and store it appropiately
+/// inside of the `PoseidonBranch` structure with the bitflags already
+/// computed and the offsets pointing to the next levels pointing also to
+/// the correct places.
+impl<C, H> From<&Branch<'_, C, H>> for PoseidonBranch
+where
+    C: Compound<H>,
+    C::Annotation: Borrow<StorageScalar>,
+    H: ByteHash,
+{
+    fn from(branch: &Branch<C, H>) -> PoseidonBranch {
+        let mut poseidon_branch = PoseidonBranch::with_capacity(branch.levels().len() - 1);
+        // Skip root and store it directly.
+        poseidon_branch.root = branch
+            .levels()
+            .first()
+            .unwrap()
+            .annotation()
+            .unwrap()
+            .borrow()
+            .to_owned()
+            .into();
+        // Store the levels with the bitflags already computed inside
+        // of our PoseidonBranch structure.
+        for level in branch.levels().iter().rev() {
+            // Generate a default mutable `PoseidonLevel`, add the corresponding data
+            // extracted from the `Branch` and push it to our poseidon branch previously
+            // generated.
+            poseidon_branch.levels.push({
+                let mut pos_level = PoseidonLevel::default();
+                let mut level_bitflags = 0u64;
+                level
+                    .children()
+                    .iter()
+                    // Copy in poseidon_branch the leave values of the actual level with an
+                    // offset of one. So then we can add the bitflags at the beggining as the
+                    // first item of the `WIDTH` ones.
+                    .zip(pos_level.leaves.iter_mut().skip(1))
+                    // If they're null, place a Scalar::zero() inside of them as stated on the
+                    // Poseidon Hash paper.
+                    .enumerate()
+                    .for_each(|(idx, (src, dest))| {
+                        *dest = match src.annotation() {
+                            Some(borrow) => {
+                                let annotation: &Scalar = &(*borrow).borrow().borrow();
+                                // If the Annotation contains a value, we set the bitflag to 1.
+                                // Since the first element will be the most significant bit of the
+                                // bitflags, we need to shift it according to the `ARITY`.
+                                //
+                                // So for example:
+                                // A level with: [Some(val), None, None, None] should correspond to
+                                // Bitflags(1000). This means that we need to shift the first element
+                                // by `ARITY` and lately decrease the shift order by `idx`.
+                                level_bitflags += 1u64 << ((ARITY - 1) - idx);
+                                *annotation
+                            }
+                            None => Scalar::zero(),
+                        };
+                    });
+                // Now we should have our bitflags value computed as well as the
+                // `WIDTH` leaves set on the [1..4] positions of our poseidon_level.
+                //
+                // We need now to add the bitflags element in pos_level.leaves[0]
+                pos_level.leaves[0] = Scalar::from(level_bitflags);
+                // Once we have the level, we get the position where the hash of the previous level is
+                // stored on the this level.
+                // NOTE that this position is in respect of a WIDTH = `ARITY` so we need to
+                // keep in mind that we've added an extra term (bitflags) and so, the index that
+                // the branch is returning is indeed pointing one position before on the next level
+                // that we will compute later. We just add 1 to it to inline the value with the
+                // new `WIDTH`
+                pos_level.offset = level.offset() + 1;
+                pos_level
+            })
+        }
+        poseidon_branch
+    }
+}
+
+impl PoseidonBranch {
+    /// Generates a default PoseidonBranch with the specified capacity for storing
+    /// `n` levels inside.
+    pub fn with_capacity(n: usize) -> Self {
+        PoseidonBranch {
+            root: Scalar::zero(),
+            levels: Vec::with_capacity(n),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+/// Represents a Merkle-Tree Level inside of a `PoseidonBranch`.
+/// It stores the leaves as `Scalar` and the offset which represents
+/// the position on the level where the hash of the previous `PoseidonLevel`
+/// is stored in.
+pub struct PoseidonLevel {
+    /// Position on the level where the hash of the previous `PoseidonLevel`
+    /// is stored in.
+    pub offset: usize,
+    /// Leaves of the Level.
+    pub leaves: [Scalar; WIDTH],
+}
+
+impl Default for PoseidonLevel {
+    fn default() -> Self {
+        PoseidonLevel {
+            offset: 0usize,
+            leaves: [Scalar::zero(); WIDTH],
+        }
+    }
+}

--- a/src/merkle_proof/poseidon_branch.rs
+++ b/src/merkle_proof/poseidon_branch.rs
@@ -37,9 +37,9 @@ where
         poseidon_branch.root = branch
             .levels()
             .first()
-            .unwrap()
+            .expect("Unexpected Error: Kelvin Branch always has a root")
             .annotation()
-            .unwrap()
+            .expect("Unexpected Error: Kelvin Branch should always suceed applying annotations")
             .borrow()
             .to_owned()
             .into();
@@ -65,7 +65,8 @@ where
                     .for_each(|(idx, (src, dest))| {
                         *dest = match src.annotation() {
                             Some(borrow) => {
-                                let annotation: &Scalar = &(*borrow).borrow().borrow();
+                                let stor_scalar: &StorageScalar = &(*borrow).borrow();
+                                let annotation: &Scalar = stor_scalar.borrow();
                                 // If the Annotation contains a value, we set the bitflag to 1.
                                 // Since the first element will be the most significant bit of the
                                 // bitflags, we need to shift it according to the `ARITY`.
@@ -73,8 +74,9 @@ where
                                 // So for example:
                                 // A level with: [Some(val), None, None, None] should correspond to
                                 // Bitflags(1000). This means that we need to shift the first element
-                                // by `ARITY` and lately decrease the shift order by `idx`.
-                                level_bitflags += 1u64 << ((ARITY - 1) - idx);
+                                // by `ARITY - 1` to select the correct position of the bit
+                                // and then decrease the shift order by `idx`.
+                                level_bitflags |= 1u64 << ((ARITY - 1) - idx);
                                 *annotation
                             }
                             None => Scalar::zero(),


### PR DESCRIPTION
- [x] Add merkle tree hashing logic for `Scalar` and `Variable` as a gadget. Closes #9 
- [x] Implement needed Kelvin-related Traits. Closes #12
- [x] Implement `From<Branch> for `PoseidonBranch`. Close #13
- [x] Create a wrapping type over Scalar to define the `Content` trait over it. Closes #14