### PR TITLE
Fix pi constraints & update lib docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ kelvin = "0.18"
 nstack = "0.4"
 lazy_static = "1.3.0"
 hades252 = { git = "https://github.com/dusk-network/hades252", version = "0.6.0" }
-dusk-plonk = {version = "0.2.0", features = ["trace-print"]}
+dusk-plonk = "0.2.6"
 
 [dev-dependencies]
 rand = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 kelvin = "0.18"
 nstack = "0.4"
 lazy_static = "1.3.0"
-hades252 = { git = "https://github.com/dusk-network/hades252", version = "0.6.0" }
+hades252 = { git = "https://github.com/dusk-network/hades252", version = "0.6.1" }
 dusk-plonk = "0.2.6"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,8 +122,9 @@
 //!     let mut verifier = Verifier::new(b"merkle_opening_tester");
 //!     gadget_tester(verifier.mut_cs());
 //!     verifier.preprocess(&ck).expect("Error on preprocessing");
+//!     let pi = verifier.mut_cs().public_inputs.clone();
 //!     assert!(verifier
-//!         .verify(&proof, &vk, &vec![BlsScalar::zero()])
+//!         .verify(&proof, &vk, &pi)
 //!         .is_ok());
 //! }
 //! ```

--- a/src/merkle_proof/proof.rs
+++ b/src/merkle_proof/proof.rs
@@ -89,13 +89,7 @@ pub fn merkle_opening_gadget(
     // Add the last check regarding the last lvl-hash agains the tree root
     // which will be a Public Input. On this case, it is not possible to make any kind
     // of cheating on the Prover side by modifying the underlying `PoseidonBranch` data.
-    let root_var_announced = composer.add_input(proven_root);
-    composer.constrain_to_constant(
-        root_var_announced,
-        proven_root,
-        BlsScalar::zero(),
-    );
-    composer.assert_equal(root_var_announced, prev_lvl_hash);
+    composer.constrain_to_constant(prev_lvl_hash, BlsScalar::zero(), -proven_root);
 
     assert_eq!(branch.root, proven_root);
 }
@@ -244,8 +238,9 @@ mod tests {
             let mut verifier = Verifier::new(b"merkle_opening_tester");
             gadget_tester(verifier.mut_cs());
             verifier.preprocess(&ck).expect("Error on preprocessing");
+            let pi = verifier.mut_cs().public_inputs.clone();
             assert!(verifier
-                .verify(&proof, &vk, &vec![BlsScalar::zero()])
+                .verify(&proof, &vk, &pi)
                 .is_ok());
         }
 

--- a/src/sponge/sponge.rs
+++ b/src/sponge/sponge.rs
@@ -136,9 +136,6 @@ mod tests {
             BlsScalar::zero(),
             BlsScalar::zero(),
         );
-
-        composer.add_dummy_constraints();
-        composer.check_circuit_satisfied();
     }
 
     #[test]


### PR DESCRIPTION
We were constraining the root against `q_c` selector
poly. This was causing the circuits to not be independent
from the root of the tree that we're working with.

We refactored it and therefore it now depends on the public
inputs.

Closes #43