### PR TITLE
Bump to v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 
-## [0.6.0] - 07-08-20
+## [0.6.1] - 13-08-20
+### Changed
+- `add_constant_witness` method replacement by `add_witness_to_circuit_description`.
+- Changed `dusk-plonk` version to `v0.2.7`.
+- Changed `Hades252` version to `v0.7.0`.
 
+## [0.6.0] - 07-08-20
 ### Changed
 - Use `dusk-plonk v0.2.0` as dependency.
 - Refactor the tests related to Proof generation to work with the Prover&Verifier abstraction.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 kelvin = "0.18"
 nstack = "0.4"
 lazy_static = "1.3.0"
-hades252 = { git = "https://github.com/dusk-network/hades252", version = "0.6.1" }
+hades252 = { git = "https://github.com/dusk-network/hades252", version = "0.7.0" }
 dusk-plonk = "0.2.7"
 anyhow = "1.0"
 thiserror = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 kelvin = "0.18"
 nstack = "0.4"
 lazy_static = "1.3.0"
-hades252 = { git = "https://github.com/dusk-network/hades252", version = "0.7.0" }
+hades252 = { git = "https://github.com/dusk-network/hades252", tag = "v0.7.0" }
 dusk-plonk = "0.2.7"
 anyhow = "1.0"
 thiserror = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ kelvin = "0.18"
 nstack = "0.4"
 lazy_static = "1.3.0"
 hades252 = { git = "https://github.com/dusk-network/hades252", version = "0.6.1" }
-dusk-plonk = "0.2.6"
+dusk-plonk = "0.2.7"
 anyhow = "1.0"
 thiserror = "1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poseidon252"
-version = "0.6.0"
+version = "0.6.1"
 authors = [
   "zer0 <matteo@dusk.network>",	"vlopes11 <victor@dusk.network>",	"CPerezz <carlos@dusk.network>", "Kristoffer Ström <kristoffer@dusk.network>"
 ]

--- a/README.md
+++ b/README.md
@@ -113,13 +113,13 @@ for i in [0u64, 567, 1023].iter() {
     // Proving
     let mut prover = Prover::new(b"merkle_opening_tester");
     gadget_tester(prover.mut_cs());
-    prover.preprocess(&ck).expect("Error on preprocessing");
-    let proof = prover.prove(&ck).expect("Error on proving");
+    prover.preprocess(&ck)?;
+    let proof = prover.prove(&ck)?;
 
     // Verify
     let mut verifier = Verifier::new(b"merkle_opening_tester");
     gadget_tester(verifier.mut_cs());
-    verifier.preprocess(&ck).expect("Error on preprocessing");
+    verifier.preprocess(&ck)?;
     assert!(verifier
         .verify(&proof, &vk, &vec![BlsScalar::zero()])
         .is_ok());

--- a/src/cipher/cipher.rs
+++ b/src/cipher/cipher.rs
@@ -192,10 +192,10 @@ impl PoseidonCipher {
         nonce: Variable,
     ) -> [Variable; WIDTH] {
         let domain = BlsScalar::from_raw([0x100000000u64, 0, 0, 0]);
-        let domain = composer.add_constant_witness(domain);
+        let domain = composer.add_witness_to_circuit_description(domain);
 
         let length = BlsScalar::from_raw([MESSAGE_CAPACITY as u64, 0, 0, 0]);
-        let length = composer.add_constant_witness(length);
+        let length = composer.add_witness_to_circuit_description(length);
 
         [domain, length, ks0, ks1, nonce]
     }

--- a/src/cipher/zk.rs
+++ b/src/cipher/zk.rs
@@ -10,7 +10,7 @@ pub fn poseidon_cipher_gadget(
     nonce: Variable,
     message: &[Variable],
 ) -> [Variable; CIPHER_SIZE] {
-    let zero = composer.add_constant_witness(BlsScalar::zero());
+    let zero = composer.add_witness_to_circuit_description(BlsScalar::zero());
 
     let ks0 = *shared_secret.x();
     let ks1 = *shared_secret.y();
@@ -84,7 +84,8 @@ mod tests {
                        nonce: BlsScalar,
                        message: &[BlsScalar],
                        cipher: &[BlsScalar]| {
-            let zero = composer.add_constant_witness(BlsScalar::zero());
+            let zero =
+                composer.add_witness_to_circuit_description(BlsScalar::zero());
             let nonce = composer.add_input(nonce);
 
             let secret = composer.add_input((secret).into());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@
 //!
 //! ### Zero Knowledge Merkle Opening Proof example:
 //!
-//! ```rust
+//! ```rust,no_run
 //! use poseidon252::{StorageScalar, PoseidonAnnotation};
 //! use poseidon252::merkle_proof::merkle_opening_gadget;
 //! use dusk_plonk::prelude::*;
@@ -79,8 +79,8 @@
 //!
 //! // Generate Composer & Public Parameters
 //! let pub_params =
-//!     PublicParameters::setup(1 << 17, &mut rand::thread_rng()).unwrap();
-//! let (ck, vk) = pub_params.trim(1 << 16).unwrap();
+//!     PublicParameters::setup(1 << 17, &mut rand::thread_rng())?;
+//! let (ck, vk) = pub_params.trim(1 << 16)?;
 //! // Generate a tree with random scalars inside.
 //! let mut ptree: PoseidonTree<_, Blake2b> = PoseidonTree::new(17);
 //! for i in 0..1024u64 {
@@ -115,13 +115,13 @@
 //!     // Proving
 //!     let mut prover = Prover::new(b"merkle_opening_tester");
 //!     gadget_tester(prover.mut_cs());
-//!     prover.preprocess(&ck).expect("Error on preprocessing");
-//!     let proof = prover.prove(&ck).expect("Error on proving");
+//!     prover.preprocess(&ck)?;
+//!     let proof = prover.prove(&ck)?;
 //!
 //!     // Verify
 //!     let mut verifier = Verifier::new(b"merkle_opening_tester");
 //!     gadget_tester(verifier.mut_cs());
-//!     verifier.preprocess(&ck).expect("Error on preprocessing");
+//!     verifier.preprocess(&ck)?;
 //!     let pi = verifier.mut_cs().public_inputs.clone();
 //!     assert!(verifier
 //!         .verify(&proof, &vk, &pi)
@@ -131,7 +131,7 @@
 //!
 //!
 //! ### Standard Merkle Opening Proof example:
-//! ```rust
+//! ```rust,no_run
 //! use poseidon252::{StorageScalar, PoseidonAnnotation};
 //! use poseidon252::merkle_proof::merkle_opening_scalar_verification;
 //! use dusk_plonk::bls12_381::Scalar as BlsScalar;

--- a/src/merkle_lvl_hash/hash.rs
+++ b/src/merkle_lvl_hash/hash.rs
@@ -108,6 +108,7 @@ pub(crate) fn merkle_level_hash_gadget_without_bitflags(
 #[cfg(test)]
 pub mod tests {
     use super::*;
+    use anyhow::Result;
 
     fn gen_random_merkle_level() -> ([Option<BlsScalar>; ARITY], BlsScalar) {
         let mut input = [Some(BlsScalar::zero()); ARITY];
@@ -151,11 +152,11 @@ pub mod tests {
     }
 
     #[test]
-    fn test_merkle_level_gadget_bitflags() {
+    fn test_merkle_level_gadget_bitflags() -> Result<()> {
         // Gen Public Params and Keys.
         let pub_params =
-            PublicParameters::setup(1 << 12, &mut rand::thread_rng()).unwrap();
-        let (ck, vk) = pub_params.trim(1 << 11).unwrap();
+            PublicParameters::setup(1 << 12, &mut rand::thread_rng())?;
+        let (ck, vk) = pub_params.trim(1 << 11)?;
 
         // Generate input merkle level
         let (level_sacalars, expected_hash) = gen_random_merkle_level();
@@ -198,20 +199,14 @@ pub mod tests {
         // Proving
         let mut prover = Prover::new(b"merkle_gadget_tester");
         composer_fill(prover.mut_cs());
-        prover
-            .preprocess(&ck)
-            .expect("Error on preprocessing stage");
-        let proof = prover.prove(&ck).expect("Error in proof generation stage");
+        prover.preprocess(&ck)?;
+        let proof = prover.prove(&ck)?;
 
         // Verification
         let mut verifier = Verifier::new(b"merkle_gadget_tester");
         composer_fill(verifier.mut_cs());
-        verifier
-            .preprocess(&ck)
-            .expect("Error on preprocessing stage");
+        verifier.preprocess(&ck)?;
 
-        assert!(verifier
-            .verify(&proof, &vk, &vec![BlsScalar::zero()])
-            .is_ok())
+        verifier.verify(&proof, &vk, &vec![BlsScalar::zero()])
     }
 }

--- a/src/sponge/sponge.rs
+++ b/src/sponge/sponge.rs
@@ -88,7 +88,7 @@ pub fn sponge_hash_gadget(
 #[cfg(test)]
 mod tests {
     use super::*;
-
+    use anyhow::Result;
     const CAPACITY: usize = 1 << 12;
 
     fn poseidon_sponge_params(width: usize) -> (Vec<BlsScalar>, BlsScalar) {
@@ -139,11 +139,11 @@ mod tests {
     }
 
     #[test]
-    fn sponge_gadget_width_3() {
+    fn sponge_gadget_width_3() -> Result<()> {
         // Setup OG params.
         let public_parameters =
-            PublicParameters::setup(CAPACITY, &mut rand::thread_rng()).unwrap();
-        let (ck, vk) = public_parameters.trim(CAPACITY).unwrap();
+            PublicParameters::setup(CAPACITY, &mut rand::thread_rng())?;
+        let (ck, vk) = public_parameters.trim(CAPACITY)?;
 
         // Test with width = 3
 
@@ -151,24 +151,22 @@ mod tests {
         let (i, o) = poseidon_sponge_params(3usize);
         let mut prover = Prover::new(b"sponge_tester");
         sponge_gadget_tester(3usize, i.clone(), o, prover.mut_cs());
-        prover.preprocess(&ck).expect("Error on preprocessing");
-        let proof = prover.prove(&ck).expect("Error on proof generation");
+        prover.preprocess(&ck)?;
+        let proof = prover.prove(&ck)?;
 
         // Verify
         let mut verifier = Verifier::new(b"sponge_tester");
         sponge_gadget_tester(3usize, i, o, verifier.mut_cs());
-        verifier.preprocess(&ck).expect("Error on preprocessing");
-        assert!(verifier
-            .verify(&proof, &vk, &vec![BlsScalar::zero()])
-            .is_ok());
+        verifier.preprocess(&ck)?;
+        verifier.verify(&proof, &vk, &vec![BlsScalar::zero()])
     }
 
     #[test]
-    fn sponge_gadget_hades_width() {
+    fn sponge_gadget_hades_width() -> Result<()> {
         // Setup OG params.
         let public_parameters =
-            PublicParameters::setup(CAPACITY, &mut rand::thread_rng()).unwrap();
-        let (ck, vk) = public_parameters.trim(CAPACITY).unwrap();
+            PublicParameters::setup(CAPACITY, &mut rand::thread_rng())?;
+        let (ck, vk) = public_parameters.trim(CAPACITY)?;
 
         // Test with width = 5
 
@@ -176,24 +174,22 @@ mod tests {
         let (i, o) = poseidon_sponge_params(WIDTH);
         let mut prover = Prover::new(b"sponge_tester");
         sponge_gadget_tester(WIDTH, i.clone(), o, prover.mut_cs());
-        prover.preprocess(&ck).expect("Error on preprocessing");
-        let proof = prover.prove(&ck).expect("Error on proof generation");
+        prover.preprocess(&ck)?;
+        let proof = prover.prove(&ck)?;
 
         // Verify
         let mut verifier = Verifier::new(b"sponge_tester");
         sponge_gadget_tester(WIDTH, i, o, verifier.mut_cs());
-        verifier.preprocess(&ck).expect("Error on preprocessing");
-        assert!(verifier
-            .verify(&proof, &vk, &vec![BlsScalar::zero()])
-            .is_ok());
+        verifier.preprocess(&ck)?;
+        verifier.verify(&proof, &vk, &vec![BlsScalar::zero()])
     }
 
     #[test]
-    fn sponge_gadget_width_15() {
+    fn sponge_gadget_width_15() -> Result<()> {
         // Setup OG params.
         let public_parameters =
-            PublicParameters::setup(1 << 17, &mut rand::thread_rng()).unwrap();
-        let (ck, vk) = public_parameters.trim(1 << 17).unwrap();
+            PublicParameters::setup(1 << 17, &mut rand::thread_rng())?;
+        let (ck, vk) = public_parameters.trim(1 << 17)?;
 
         // Test with width = 15
 
@@ -201,15 +197,13 @@ mod tests {
         let (i, o) = poseidon_sponge_params(15usize);
         let mut prover = Prover::new(b"sponge_tester");
         sponge_gadget_tester(15usize, i.clone(), o, prover.mut_cs());
-        prover.preprocess(&ck).expect("Error on preprocessing");
-        let proof = prover.prove(&ck).expect("Error on proof generation");
+        prover.preprocess(&ck)?;
+        let proof = prover.prove(&ck)?;
 
         // Verify
         let mut verifier = Verifier::new(b"sponge_tester");
         sponge_gadget_tester(15usize, i, o, verifier.mut_cs());
-        verifier.preprocess(&ck).expect("Error on preprocessing");
-        assert!(verifier
-            .verify(&proof, &vk, &vec![BlsScalar::zero()])
-            .is_ok());
+        verifier.preprocess(&ck)?;
+        verifier.verify(&proof, &vk, &vec![BlsScalar::zero()])
     }
 }


### PR DESCRIPTION
Make the tests return `anyhow::Error` -> This allows us to remove the massive amount of
`expect` and `unwrap` usage that we have while propagating
the errors on the tests.

- Modified the docs to actually behave on the same way.
- Added `no_run` flag to the lib docs to not run the examples
on every build.
- Bumped `dusk_plonk` & `hades252` to the latest versions.
- Bump Poseidon252 to `v0.6.1`