### PR TITLE
Adding fixed hash length

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,6 +200,8 @@ pub mod merkle_lvl_hash;
 pub mod merkle_proof;
 /// Reference implementation for the Poseidon Sponge hash function
 pub mod sponge;
+/// Module containing a fixed-length Poseidon hash implementation
+pub mod perm_uses;
 
 /// The module handling posedion-trees
 pub mod tree;

--- a/src/perm_uses/fixed_hash.rs
+++ b/src/perm_uses/fixed_hash.rs
@@ -1,12 +1,11 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 // Licensed under the MPL 2.0 license. See LICENSE file in the project root for details.”
-//! The `pad` module implements the Sponge's padding algorithm
-use crate::sponge::pad::*;
+//! The `pad` module implements the padding algorithm on the Poseidon hash.
+use super::pad::*;
 
 use dusk_plonk::prelude::*;
 use hades252::strategies::*;
 use hades252::WIDTH;
-
 
 /// Takes in one BlsScalar and outputs 2. 
 /// This function is fixed.
@@ -16,30 +15,15 @@ pub fn two_outputs(message: BlsScalar) -> [BlsScalar; 2] {
     // The value used to pad the words is zero.
     let padder = BlsScalar::zero();
 
-    // The capacity is 
-    let capacity = BlsScalar::one() * BlsScalar::from(2<<64-1) + BlsScalar::one(); 
+       // The capacity is 
+       let capacity = BlsScalar::one() * BlsScalar::from(2<<64-1) + BlsScalar::one(); 
 
     let mut words = pad_fixed_hash(capacity, message, padder);
-    // If the words len is less than the Hades252 permutation `WIDTH` we directly
-    // call the permutation saving useless additions by zero.
-    if words.len() == WIDTH {
-        strategy.perm(&mut words);
-        return [words[1], words[2]];
-    }
-    // If the words len is bigger than the Hades252 permutation `WIDTH` then we
-    // need to collapse the padded limbs. See bottom of pag. 16 of
-    // https://eprint.iacr.org/2019/458.pdf
-    words.chunks(WIDTH).fold(
-        vec![BlsScalar::zero(); WIDTH],
-        |mut inputs, values| {
-            let mut values = values.iter();
-            inputs
-                .iter_mut()
-                .for_each(|input| *input += values.next().unwrap());
-            strategy.perm(&mut inputs);
-            inputs
-        },
-    );
+    // Since we do a fixed_length hash, `words` is always
+    // the size of `WIDTH`. Therefore, we can simply do
+    // the permutation and return the desired results.
+    strategy.perm(&mut words);
+    
     [words[1], words[2]]
 } 
 
@@ -61,11 +45,15 @@ mod tests {
 
     #[test]
     fn same_result() {
+
+        for _i in 0..100 {
         let m = BlsScalar::random(&mut rand::thread_rng()); 
+        
         
         let h = two_outputs(m); 
         let h_1 = two_outputs(m);
-        
+
         assert_eq!(h, h_1);
+        }
     }
 }

--- a/src/perm_uses/fixed_hash.rs
+++ b/src/perm_uses/fixed_hash.rs
@@ -1,0 +1,71 @@
+// Copyright (c) DUSK NETWORK. All rights reserved.
+// Licensed under the MPL 2.0 license. See LICENSE file in the project root for details.”
+//! The `pad` module implements the Sponge's padding algorithm
+use crate::sponge::pad::*;
+
+use dusk_plonk::prelude::*;
+use hades252::strategies::*;
+use hades252::WIDTH;
+
+
+/// Takes in one BlsScalar and outputs 2. 
+/// This function is fixed.
+pub fn two_outputs(message: BlsScalar) -> [BlsScalar; 2] {
+    let mut strategy = ScalarStrategy::new();
+
+    // The value used to pad the words is zero.
+    let padder = BlsScalar::zero();
+
+    // The capacity is 
+    let capacity = BlsScalar::one() * BlsScalar::from(2<<64-1) + BlsScalar::one(); 
+
+    let mut words = pad_fixed_hash(capacity, message, padder);
+    // If the words len is less than the Hades252 permutation `WIDTH` we directly
+    // call the permutation saving useless additions by zero.
+    if words.len() == WIDTH {
+        strategy.perm(&mut words);
+        return [words[1], words[2]];
+    }
+    // If the words len is bigger than the Hades252 permutation `WIDTH` then we
+    // need to collapse the padded limbs. See bottom of pag. 16 of
+    // https://eprint.iacr.org/2019/458.pdf
+    words.chunks(WIDTH).fold(
+        vec![BlsScalar::zero(); WIDTH],
+        |mut inputs, values| {
+            let mut values = values.iter();
+            inputs
+                .iter_mut()
+                .for_each(|input| *input += values.next().unwrap());
+            strategy.perm(&mut inputs);
+            inputs
+        },
+    );
+    [words[1], words[2]]
+} 
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    #[test]
+    fn sponge_hash_two_outputs() {
+        let m = BlsScalar::random(&mut rand::thread_rng()); 
+        
+        let h = two_outputs(m); 
+        
+        assert_eq!(h.len(), 2);
+        assert_ne!(m, BlsScalar::zero());
+        assert_ne!(h[0], BlsScalar::zero());
+        assert_ne!(h[1], BlsScalar::zero());
+    }
+
+    #[test]
+    fn same_result() {
+        let m = BlsScalar::random(&mut rand::thread_rng()); 
+        
+        let h = two_outputs(m); 
+        let h_1 = two_outputs(m);
+        
+        assert_eq!(h, h_1);
+    }
+}

--- a/src/perm_uses/fixed_hash.rs
+++ b/src/perm_uses/fixed_hash.rs
@@ -48,7 +48,7 @@ mod tests {
     use super::*;
     
     #[test]
-    fn sponge_hash_two_outputs() {
+    fn hash_two_outputs() {
         let m = BlsScalar::random(&mut rand::thread_rng()); 
         
         let h = two_outputs(m); 

--- a/src/perm_uses/mod.rs
+++ b/src/perm_uses/mod.rs
@@ -2,3 +2,5 @@
 // Licensed under the MPL 2.0 license. See LICENSE file in the project root for details.”
 
 pub mod fixed_hash;
+
+mod pad;

--- a/src/perm_uses/mod.rs
+++ b/src/perm_uses/mod.rs
@@ -1,0 +1,4 @@
+// Copyright (c) DUSK NETWORK. All rights reserved.
+// Licensed under the MPL 2.0 license. See LICENSE file in the project root for details.”
+
+pub mod fixed_hash;

--- a/src/perm_uses/pad.rs
+++ b/src/perm_uses/pad.rs
@@ -1,0 +1,24 @@
+// Copyright (c) DUSK NETWORK. All rights reserved.
+// Licensed under the MPL 2.0 license. See LICENSE file in the project root for details.”
+//! Padding support for Poseidon hash
+//!
+
+// Padding function for a singular scalar input 
+// to provide two outputs from a Poseidon hash
+pub fn pad_fixed_hash <T>(
+    capacity: T,
+    message: T,
+    pad_value: T,
+) -> Vec<T>
+where
+    T: Clone,
+{
+    // For a constant length hash, we always use a slice of width 5.
+    let width = 5;
+    let zero = pad_value;
+    let mut words = vec![zero; width];
+
+    words[0] = capacity;
+    words[1] = message;
+    words
+}

--- a/src/sponge/pad.rs
+++ b/src/sponge/pad.rs
@@ -35,6 +35,26 @@ where
     words
 }
 
+// Padding function for a singular scalar input 
+// to provide two outputs from a Poseidon hash
+pub fn pad_fixed_hash <T>(
+    capacity: T,
+    message: T,
+    pad_value: T,
+) -> Vec<T>
+where
+    T: Clone,
+{
+    // For a constant length hash, we always use a slice of width 5.
+    let width = 5;
+    let zero = pad_value;
+    let mut words = vec![zero; width];
+
+    words[0] = capacity;
+    words[1] = message;
+    words
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/sponge/pad.rs
+++ b/src/sponge/pad.rs
@@ -35,25 +35,6 @@ where
     words
 }
 
-// Padding function for a singular scalar input 
-// to provide two outputs from a Poseidon hash
-pub fn pad_fixed_hash <T>(
-    capacity: T,
-    message: T,
-    pad_value: T,
-) -> Vec<T>
-where
-    T: Clone,
-{
-    // For a constant length hash, we always use a slice of width 5.
-    let width = 5;
-    let zero = pad_value;
-    let mut words = vec![zero; width];
-
-    words[0] = capacity;
-    words[1] = message;
-    words
-}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This PR adds a function which allows us to take in one BlsScalar and output 2. This is for use in the EdDSA scheme for JubJub. 
This closes #51. 