### PR TITLE
Extract PI check from merkle_opening_gadget fn

### DIFF
--- a/src/perm_uses/fixed_hash.rs
+++ b/src/perm_uses/fixed_hash.rs
@@ -5,9 +5,8 @@ use super::pad::*;
 
 use dusk_plonk::prelude::*;
 use hades252::strategies::*;
-use hades252::WIDTH;
 
-/// Takes in one BlsScalar and outputs 2. 
+/// Takes in one BlsScalar and outputs 2.
 /// This function is fixed.
 pub fn two_outputs(message: BlsScalar) -> [BlsScalar; 2] {
     let mut strategy = ScalarStrategy::new();
@@ -15,28 +14,29 @@ pub fn two_outputs(message: BlsScalar) -> [BlsScalar; 2] {
     // The value used to pad the words is zero.
     let padder = BlsScalar::zero();
 
-       // The capacity is 
-       let capacity = BlsScalar::one() * BlsScalar::from(2<<64-1) + BlsScalar::one(); 
+    // The capacity is
+    let capacity =
+        BlsScalar::one() * BlsScalar::from(2 << 64 - 1) + BlsScalar::one();
 
     let mut words = pad_fixed_hash(capacity, message, padder);
     // Since we do a fixed_length hash, `words` is always
     // the size of `WIDTH`. Therefore, we can simply do
     // the permutation and return the desired results.
     strategy.perm(&mut words);
-    
+
     [words[1], words[2]]
-} 
+}
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     #[test]
     fn hash_two_outputs() {
-        let m = BlsScalar::random(&mut rand::thread_rng()); 
-        
-        let h = two_outputs(m); 
-        
+        let m = BlsScalar::random(&mut rand::thread_rng());
+
+        let h = two_outputs(m);
+
         assert_eq!(h.len(), 2);
         assert_ne!(m, BlsScalar::zero());
         assert_ne!(h[0], BlsScalar::zero());
@@ -45,15 +45,13 @@ mod tests {
 
     #[test]
     fn same_result() {
-
         for _i in 0..100 {
-        let m = BlsScalar::random(&mut rand::thread_rng()); 
-        
-        
-        let h = two_outputs(m); 
-        let h_1 = two_outputs(m);
+            let m = BlsScalar::random(&mut rand::thread_rng());
 
-        assert_eq!(h, h_1);
+            let h = two_outputs(m);
+            let h_1 = two_outputs(m);
+
+            assert_eq!(h, h_1);
         }
     }
 }


### PR DESCRIPTION
Since we're planning to impl the `CircuitBuilder` trait for our
circuits, the checks agains PI should be done outside the gadgets
and in the scope of the `CircuitBuilder` impl.

Therefore, we made the replacement and refactored the tests accordingly.

Closes #58