### PR TITLE
Bump version to 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 23-09-20
+### Changed
+- Removed PI constraint from `merkle_opening_gadget` to implement
+`CircuitBuilder` trait.
+- Use `nstack 0.5.0`
+
+
 ## [0.6.4] - 07-09-20
 ### Added
 - `PoseidonCipher` from/to bytes.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ authors = [
 edition = "2018"
 
 [dependencies]
-kelvin = "0.18"
-nstack = "0.4"
+kelvin = "0.19.0"
+nstack = "0.5"
 lazy_static = "1.3.0"
 hades252 = { git = "https://github.com/dusk-network/hades252", tag = "v0.7.0" }
 dusk-plonk = "0.2.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poseidon252"
-version = "0.6.4"
+version = "0.7.0"
 authors = [
   "zer0 <matteo@dusk.network>",	"vlopes11 <victor@dusk.network>",	"CPerezz <carlos@dusk.network>", "Kristoffer Ström <kristoffer@dusk.network>"
 ]


### PR DESCRIPTION
- update `nstack` (from `0.4` to `0.5`)
- update `kelvin` (from `0.18` to `0.19`)

We wanted to update kelvin to the latest possible version.
But there was a problem where Poseidon wasn't compiling with different version of `nstack` in it; so we had to update `nstack` too.

Closes #57