### PR TITLE
Refactor padding for PoseidonBranch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 04-10-20
+### Added
+- `root()` fn for `PoseidonBranch`.
+
+### Changed
+- Padding implementation for `PoseidonBranch` with opening gadgets.
+
+### Removed
+- Extension fn's from the crate.
+
 ## [0.8.1] - 01-10-20
 ### Changed
 - Implement `inner` and `inner_mut` methods on PoseidonTree

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poseidon252"
-version = "0.8.1"
+version = "0.9.0"
 authors = [
   "zer0 <matteo@dusk.network>",	"vlopes11 <victor@dusk.network>",	"CPerezz <carlos@dusk.network>", "Kristoffer Ström <kristoffer@dusk.network>"
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 kelvin = "0.19.0"
 nstack = "0.5"
 lazy_static = "1.3.0"
-hades252 = { git = "https://github.com/dusk-network/hades252", tag = "v0.8.0" }
+hades252 = { git = "https://github.com/dusk-network/hades252", tag = "v0.8.1" }
 dusk-plonk = {version = "0.2.11", features = ["trace-print"]}
 anyhow = "1.0"
 thiserror = "1.0"

--- a/src/merkle_proof/proof.rs
+++ b/src/merkle_proof/proof.rs
@@ -42,7 +42,7 @@ pub fn merkle_opening_gadget(
     // Generate and constraint zero.
     let zero = composer.add_witness_to_circuit_description(BlsScalar::zero());
     // Allocate space for each level Variables that will be generated.
-    let mut lvl_vars = unsafe { [std::mem::zeroed(); WIDTH] };
+    let mut lvl_vars = [zero; WIDTH];
     // Allocate space for the last level computed hash as a variable to compare
     // it against the root.
     let mut prev_lvl_hash: Variable;

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -209,6 +209,7 @@ mod test {
             )
         })?;
         let pbranch = PoseidonBranch::from(&branch);
-        assert_eq!(tree.root()?, pbranch.root)
+        assert_eq!(tree.root()?, pbranch.root);
+        Ok(())
     }
 }


### PR DESCRIPTION
We realized that there was a problem with the previous extend
approach used by the PoseidonBranch.
It was extending the branch on a way on which it was also forced to
modify the root. The problem is obvious, and it's that the Verifier
has the original root, not the extended one (which doesn't even exist).

Therefore, we've refactored the extension and it's just only applied to
the gadget opening, not to the scalar one since it's not important at all
to pad there (we don't care about constant-size branches on the "out of
circuits" domain.

- Removed extension fn's for the gadget and the scalar approaches.
- Refactored the padding in order to be performed on a different way:
We now load into the PoseidonBranch the levels required to pad the
branch and they're set to zero. Once this is done, inside of the gadget,
we hash them without any other purpose rather than obtain the same
amount of constrats for all of the circuits. We can understand this
padding as an addition of dummy constraints.
- Refactored From<&Branch> for PoseidonBranch impl.
- Added a `root()` method for branch and made it's internals
`pub(crate)`.
- Refactored `merkle_opening_gadget` to perform the dummy constraints as
padding inside.
- Bumped the crate to a new minor version since we introduce breaking changes.

Closes #71