### PR TITLE
Port Poseidon repo to be Canon-compatible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,13 +7,15 @@ authors = [
 edition = "2018"
 
 [dependencies]
-kelvin = "0.19.0"
-nstack = "0.5"
+kelvin = { path = "../kelvin" }
+nstack = { path = "../nstack" }
 lazy_static = "1.3.0"
-hades252 = { git = "https://github.com/dusk-network/hades252", tag = "v0.9.0" }
-dusk-plonk = {version = "0.3.1", features = ["trace-print"]}
+hades252 = { git = "https://github.com/dusk-network/hades252", branch = "derive_canon" }
+dusk-plonk = { git = "https://github.com/dusk-network/plonk", branch = "derive_canon", features = ["trace-print"]}
 anyhow = "1.0"
 thiserror = "1.0"
+canonical = "0.1.0"
+canonical_derive = "0.1.0"
 
 [dev-dependencies]
 rand = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ anyhow = "1.0"
 thiserror = "1.0"
 canonical = "0.1.0"
 canonical_derive = "0.1.0"
+canonical_host = { version = "0.1.0" }
 
 [dev-dependencies]
 rand = "0.7"

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ computed and placed in the first Level position.
 use poseidon252::{StorageScalar, PoseidonAnnotation};
 use poseidon252::merkle_proof::merkle_opening_gadget;
 use dusk_plonk::prelude::*;
-use kelvin::{Blake2b, Compound};
+use canonical_host::MemStore;
 use kelvin_hamt::{HAMTSearch, NarrowHAMT};
 
 // Generate Composer & Public Parameters
@@ -80,7 +80,7 @@ let pub_params =
     PublicParameters::setup(1 << 17, &mut rand::thread_rng()).unwrap();
 let (ck, vk) = pub_params.trim(1 << 16).unwrap();
 // Generate a tree with random scalars inside.
-let mut ptree: PoseidonTree<_, Blake2b> = PoseidonTree::new(17);
+let mut ptree: PoseidonTree<_, MemStore> = PoseidonTree::new(17);
 for i in 0..1024u64 {
     ptree
         .push(StorageScalar(BlsScalar::from(i as u64)))
@@ -132,11 +132,11 @@ for i in [0u64, 567, 1023].iter() {
 use poseidon252::{StorageScalar, PoseidonAnnotation};
 use poseidon252::merkle_proof::merkle_opening_scalar_verification;
 use dusk_plonk::bls12_381::Scalar as BlsScalar;
-use kelvin::{Blake2b, Compound};
+use canonical_host::MemStore;
 use poseidon252::PoseidonTree;
 
  // Generate a tree with random scalars inside.
-let mut ptree: PoseidonTree<_, Blake2b> = PoseidonTree::new(17);
+let mut ptree: PoseidonTree<_, MemStore> = PoseidonTree::new(17);
 for i in 0..1024u64 {
     ptree
         .push(StorageScalar(BlsScalar::from(i as u64)))

--- a/src/cipher/cipher.rs
+++ b/src/cipher/cipher.rs
@@ -4,17 +4,16 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use dusk_plonk::jubjub::AffinePoint;
-use dusk_plonk::prelude::*;
-use hades252::{ScalarStrategy, Strategy, WIDTH};
-
+pub use super::CipherError;
 use super::{
     CIPHER_BYTES_SIZE, CIPHER_SIZE, ENCRYPTED_DATA_SIZE, MESSAGE_CAPACITY,
 };
-
+use canonical::Canon;
+use canonical_derive::Canon;
+use dusk_plonk::jubjub::AffinePoint;
+use dusk_plonk::prelude::*;
+use hades252::{ScalarStrategy, Strategy, WIDTH};
 use std::io;
-
-pub use super::CipherError;
 
 /// ```ignore
 /// Encapsulates an encrypted data
@@ -88,7 +87,7 @@ pub use super::CipherError;
 ///         .expect("Failed to decrypt!")
 /// }
 /// ```
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Default)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Default, Canon)]
 pub struct PoseidonCipher {
     cipher: [BlsScalar; CIPHER_SIZE],
 }

--- a/src/hashing_utils/poseidon_annotation.rs
+++ b/src/hashing_utils/poseidon_annotation.rs
@@ -11,7 +11,6 @@ use crate::ARITY;
 use dusk_plonk::bls12_381::Scalar as BlsScalar;
 use kelvin::{annotation, annotations::Cardinality, Combine, ErasedAnnotation};
 use std::borrow::Borrow;
-use std::io;
 
 #[macro_export]
 /// Extends `StorageScalar` for a provided type
@@ -26,7 +25,7 @@ use std::io;
 macro_rules! extend_storage_scalar {
     ($id:ident, $scalar:ty, $type:ty) => {
         #[derive(
-            Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord,
+            Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Canon,
         )]
         pub struct $id(poseidon252::StorageScalar);
 
@@ -101,21 +100,6 @@ macro_rules! extend_storage_scalar {
         impl std::borrow::Borrow<poseidon252::StorageScalar> for $id {
             fn borrow(&self) -> &poseidon252::StorageScalar {
                 &self.0
-            }
-        }
-
-        impl kelvin::Content<kelvin::Blake2b> for $id {
-            fn persist(
-                &mut self,
-                sink: &mut kelvin::Sink<kelvin::Blake2b>,
-            ) -> std::io::Result<()> {
-                self.0.persist(sink)
-            }
-
-            fn restore(
-                source: &mut kelvin::Source<kelvin::Blake2b>,
-            ) -> std::io::Result<Self> {
-                poseidon252::StorageScalar::restore(source).map(|s| s.into())
             }
         }
 

--- a/src/hashing_utils/scalar_storage.rs
+++ b/src/hashing_utils/scalar_storage.rs
@@ -7,19 +7,18 @@
 //! This module defines a Wrap-up over the dusk-bls12_381 to define it's kelvin
 //! storage traits
 
+use canonical::Canon;
+use canonical_derive::Canon;
 use dusk_plonk::bls12_381::Scalar as BlsScalar;
-use kelvin::{ByteHash, Content, Sink, Source};
 use std::borrow::Borrow;
-use std::io;
-use std::io::Read;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 /// This struct is a Wrapper type over the bls12-381 `Scalar` which has implemented
 /// inside the logic to allows `Kelvin` Merkle Trees understand how to store `Scalar`s
 /// inside of their leaves.
 ///
 /// This Struct is the one that we will use inside of our SmartContract storage logic to
 /// encode/compress all of our Data Structures data into a single `Scalar`.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Canon)]
 pub struct StorageScalar(pub BlsScalar);
 
 impl Default for StorageScalar {
@@ -59,28 +58,5 @@ impl From<BlsScalar> for StorageScalar {
 impl Into<BlsScalar> for StorageScalar {
     fn into(self) -> BlsScalar {
         self.0
-    }
-}
-
-// Implements logic for storing Scalar inside of kelvin
-impl<H> Content<H> for StorageScalar
-where
-    H: ByteHash,
-{
-    fn persist(&mut self, sink: &mut Sink<H>) -> io::Result<()> {
-        self.0.to_bytes().persist(sink)
-    }
-
-    fn restore(source: &mut Source<H>) -> io::Result<Self> {
-        let mut bytes = [0u8; 32];
-        // The solution with iterators is a way more messy.
-        // See: https://doc.rust-lang.org/stable/rust-by-example/error/iter_result.html
-        source.read_exact(&mut bytes)?;
-        let might_be_scalar = BlsScalar::from_bytes(&bytes);
-        if might_be_scalar.is_none().unwrap_u8() == 1u8 {
-            return Err(std::io::ErrorKind::InvalidData.into());
-        };
-        // Now it's safe to unwrap.
-        return Ok(StorageScalar(might_be_scalar.unwrap()));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@
 //! use poseidon252::merkle_proof::merkle_opening_gadget;
 //! use dusk_plonk::prelude::*;
 //! use poseidon252::PoseidonTree;
-//! use kelvin::{Blake2b, Compound};
+//! use canonical_host::MemStore;
 //! use anyhow::Result;
 //!
 //! fn main() -> Result<()> {
@@ -89,7 +89,7 @@
 //!      PublicParameters::setup(1 << 17, &mut rand::thread_rng())?;
 //!  let (ck, vk) = pub_params.trim(1 << 16)?;
 //!  // Generate a tree with random scalars inside.
-//!  let mut ptree: PoseidonTree<_, PoseidonAnnotation, Blake2b> = PoseidonTree::new(17);
+//!  let mut ptree: PoseidonTree<_, PoseidonAnnotation, MemStore> = PoseidonTree::new(17);
 //!  for i in 0..1024u64 {
 //!      ptree
 //!          .push(StorageScalar(BlsScalar::from(i as u64)))
@@ -140,11 +140,12 @@
 //! use poseidon252::{StorageScalar, PoseidonAnnotation};
 //! use poseidon252::merkle_proof::merkle_opening_scalar_verification;
 //! use dusk_plonk::bls12_381::Scalar as BlsScalar;
-//! use kelvin::{Blake2b, Compound};
+//! use kelvin::Compound;
+//! use canonical_host::MemStore;
 //! use poseidon252::PoseidonTree;
 //!
 //!  // Generate a tree with random scalars inside.
-//! let mut ptree: PoseidonTree<_, PoseidonAnnotation, Blake2b> = PoseidonTree::new(17);
+//! let mut ptree: PoseidonTree<_, PoseidonAnnotation, MemStore> = PoseidonTree::new(17);
 //! for i in 0..1024u64 {
 //!     ptree
 //!         .push(StorageScalar(BlsScalar::from(i as u64)))

--- a/src/merkle_proof/poseidon_branch.rs
+++ b/src/merkle_proof/poseidon_branch.rs
@@ -7,9 +7,10 @@
 //! Definitions of the merkle tree structure seen in Poseidon.
 use crate::hashing_utils::scalar_storage::StorageScalar;
 use crate::ARITY;
+use canonical::Store;
 use dusk_plonk::bls12_381::Scalar as BlsScalar;
 use hades252::WIDTH;
-use kelvin::{Branch, ByteHash, Compound};
+use kelvin::{Branch, Compound};
 use std::borrow::Borrow;
 
 /// The `Poseidon` structure will accept a number of inputs equal to the arity.
@@ -34,13 +35,13 @@ pub struct PoseidonBranch {
 /// inside of the `PoseidonBranch` structure with the bitflags already
 /// computed and the offsets pointing to the next levels pointing also to
 /// the correct places.
-impl<C, H> From<&Branch<'_, C, H>> for PoseidonBranch
+impl<C, S> From<&Branch<'_, C, S>> for PoseidonBranch
 where
-    C: Compound<H>,
+    C: Compound<S>,
     C::Annotation: Borrow<StorageScalar>,
-    H: ByteHash,
+    S: Store,
 {
-    fn from(branch: &Branch<C, H>) -> PoseidonBranch {
+    fn from(branch: &Branch<C, S>) -> PoseidonBranch {
         let mut poseidon_branch = PoseidonBranch::new();
 
         // Skip root and store it directly.

--- a/src/merkle_proof/proof.rs
+++ b/src/merkle_proof/proof.rs
@@ -192,12 +192,12 @@ mod tests {
     use crate::hashing_utils::scalar_storage::StorageScalar;
     use crate::{PoseidonAnnotation, PoseidonTree};
     use anyhow::Result;
-    use kelvin::Blake2b;
+    use canonical_host::MemStore;
 
     #[test]
     fn scalar_merkle_proof() {
         // Generate a tree with random scalars inside.
-        let mut ptree: PoseidonTree<_, PoseidonAnnotation, Blake2b> =
+        let mut ptree: PoseidonTree<_, PoseidonAnnotation, MemStore> =
             PoseidonTree::new(17);
         for i in 0..1024u64 {
             ptree
@@ -232,7 +232,7 @@ mod tests {
             PublicParameters::setup(1 << 17, &mut rand::thread_rng())?;
         let (ck, vk) = pub_params.trim(1 << 16)?;
         // Generate a tree with random scalars inside.
-        let mut ptree: PoseidonTree<_, PoseidonAnnotation, Blake2b> =
+        let mut ptree: PoseidonTree<_, PoseidonAnnotation, MemStore> =
             PoseidonTree::new(17);
         for i in 0..1024u64 {
             ptree


### PR DESCRIPTION
We need to be able to implement/derive `Canon` for the trees
that we use in our Smart Contracts. Therefore this crate needed a
refactor so that the Annotations and Tree structures that it exports
carry the Canon traits implemented propperly.

- Removed legacy trait implementations such as kelvin::Content
, ByteHash & others which have been deprecated.
- Enforce that `PoseidonTree` and `PoseidonBranch` store types
which implement `Canon<canonical::Store>`
- Refactor all of the trait implementations to have `Canon` implemented.
- Fixed & refactored the `extend_storage_scalar` macro so that it derives
`Canon`.
- Refactored the error handling to use correctly the
`Store::InvalidEncoding` cannonical error type.
- Removed the Associative trait bound for `PoseidonTree` &
`PoseidonBranch` & `PoseidonIterator`.
- Remove `Blake2b` in favor of `canon_host::MemStore`.

Closes #79

## IMPORTANT
This PR can not be merged until:
- kelvin integration with canonical/port to no_std gets released. See [this](https://github.com/dusk-network/kelvin/issues/50) 
- kelvin being no_std. See [this](https://github.com/dusk-network/kelvin/issues/48)

Will replace the paths by the crates.io versions once we start the bumping cascade which is blocked by the issues mentioned above.