### PR TITLE
Derive `Canon` for `PoseidonCipher`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 lazy_static = "1.3.0"
 hades252 = { git = "https://github.com/dusk-network/hades252", tag = "v0.10.0" }
-dusk-plonk = {version = "0.3.1", features = ["trace-print"]}
+dusk-plonk = {version = "0.3.2", features = ["trace-print"]}
 anyhow = "1.0"
 thiserror = "1.0"
 canonical = "0.4"

--- a/src/cipher/cipher.rs
+++ b/src/cipher/cipher.rs
@@ -4,6 +4,8 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+use canonical::Canon;
+use canonical_derive::Canon;
 use dusk_plonk::jubjub::AffinePoint;
 use dusk_plonk::prelude::*;
 use hades252::{ScalarStrategy, Strategy, WIDTH};
@@ -88,7 +90,7 @@ pub use super::CipherError;
 ///         .expect("Failed to decrypt!")
 /// }
 /// ```
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Default)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Default, Canon)]
 pub struct PoseidonCipher {
     cipher: [BlsScalar; CIPHER_SIZE],
 }


### PR DESCRIPTION
It was needed to be derived since otherways we will
not be able to derive Canon for Note & Bid Structures
and therefore, neither for the Genesis Contracts.

Closes #86