### PR TITLE
Add gate-featured `Canon` impl/usage

### DIFF
--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --release
+          args: --release --features canon
 
   fmt:
     name: Rustfmt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Gate-featured `canonnical` impl.
+- Gate-featured `canonical` impl.
 
 ## [0.11.0] - 30-10-20
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Gate-featured `canonnical` impl.
 
 ## [0.11.0] - 30-10-20
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ anyhow = "1.0"
 thiserror = "1.0"
 canonical = {version = "0.4", optional = true}
 canonical_derive = {version = "0.4", optional = true}
-microkelvin = "0.5"
-nstack = "0.6"
+microkelvin = {version = "0.5", optional = true}
+nstack = {version = "0.6", optional = true}
 
 [dev-dependencies]
 canonical_host = "0.4"
@@ -24,7 +24,7 @@ rand_core = "0.5"
 criterion = "0.3"
 
 [features]
-canon = ["canonical", "canonical_derive", "dusk-plonk/canon"]
+canon = ["canonical", "canonical_derive", "nstack", "microkelvin", "dusk-plonk/canon"]
 
 [profile.dev]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,11 @@ edition = "2018"
 [dependencies]
 lazy_static = "1.3.0"
 hades252 = { git = "https://github.com/dusk-network/hades252", tag = "v0.10.0" }
-dusk-plonk = {version = "0.3.2", features = ["trace-print"]}
+dusk-plonk = {version = "0.3.3", features = ["trace-print"]}
 anyhow = "1.0"
 thiserror = "1.0"
-canonical = "0.4"
-canonical_derive = "0.4"
+canonical = {version = "0.4", optional = true}
+canonical_derive = {version = "0.4", optional = true}
 microkelvin = "0.5"
 nstack = "0.6"
 
@@ -22,6 +22,9 @@ canonical_host = "0.4"
 rand = "0.7"
 rand_core = "0.5"
 criterion = "0.3"
+
+[features]
+canon = ["canonical", "canonical_derive", "dusk-plonk/canon"]
 
 [profile.dev]
 opt-level = 3

--- a/src/cipher/cipher.rs
+++ b/src/cipher/cipher.rs
@@ -4,7 +4,9 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+#[cfg(feature = "canon")]
 use canonical::Canon;
+#[cfg(feature = "canon")]
 use canonical_derive::Canon;
 use dusk_plonk::jubjub::AffinePoint;
 use dusk_plonk::prelude::*;
@@ -90,7 +92,8 @@ pub use super::CipherError;
 ///         .expect("Failed to decrypt!")
 /// }
 /// ```
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Default, Canon)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Default)]
+#[cfg_attr(feature = "canon", derive(Canon))]
 pub struct PoseidonCipher {
     cipher: [BlsScalar; CIPHER_SIZE],
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,4 +170,5 @@ pub mod perm_uses;
 /// Reference implementation for the Poseidon Sponge hash function
 pub mod sponge;
 /// The module handling posedion-trees
+#[cfg(feature = "canon")]
 pub mod tree;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@
 //!
 //! ### Zero Knowledge Merkle Opening Proof example:
 //!
-//! ```no_run
+//! ```ignore
 //! use anyhow::Result;
 //! use canonical::Canon;
 //! use canonical_derive::Canon;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,6 +169,6 @@ pub mod cipher;
 pub mod perm_uses;
 /// Reference implementation for the Poseidon Sponge hash function
 pub mod sponge;
-/// The module handling posedion-trees
+/// The module handling posedion-trees.
 #[cfg(feature = "canon")]
 pub mod tree;

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -7,7 +7,7 @@
 use anyhow::{anyhow, Result};
 
 #[cfg(feature = "canon")]
-use canonical::{Canon,Store};
+use canonical::{Canon, Store};
 use core::borrow::Borrow;
 use dusk_plonk::prelude::BlsScalar;
 use microkelvin::{Annotation, Cardinality, Nth};
@@ -32,7 +32,6 @@ mod tests;
 #[derive(Debug, Clone)]
 pub struct PoseidonTree<L, A, S, const DEPTH: usize>
 where
-
     L: Canon<S>,
     L: Clone,
     for<'a> &'a L: Into<BlsScalar>,

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -5,7 +5,9 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use anyhow::{anyhow, Result};
-use canonical::{Canon, Store};
+
+
+use canonical::{Canon,Store};
 use core::borrow::Borrow;
 use dusk_plonk::prelude::BlsScalar;
 use microkelvin::{Annotation, Cardinality, Nth};
@@ -30,6 +32,7 @@ mod tests;
 #[derive(Debug, Clone)]
 pub struct PoseidonTree<L, A, S, const DEPTH: usize>
 where
+
     L: Canon<S>,
     L: Clone,
     for<'a> &'a L: Into<BlsScalar>,

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -6,7 +6,7 @@
 
 use anyhow::{anyhow, Result};
 
-
+#[cfg(feature = "canon")]
 use canonical::{Canon,Store};
 use core::borrow::Borrow;
 use dusk_plonk::prelude::BlsScalar;

--- a/src/tree/tests.rs
+++ b/src/tree/tests.rs
@@ -4,6 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+#![cfg(feature = "canon")]
 use crate::tree::zk::merkle_opening;
 use crate::tree::{PoseidonAnnotation, PoseidonTree};
 use anyhow::Result;


### PR DESCRIPTION
Since we don't necessarily need `Canon` derived for
our structures. Therefore, a gate-featured solution for
canonnical and it's deps is the best solution.

Therefore, `Canon` is not derived for `PoseidonCipher` unless
we use the `canon` feature.
Same happens for the `PoseidonTree`. The tree module will not be
exported if the `canon` feature is not used.