### PR TITLE
Minimal no_std split of the lib to support no_std structs definition

### DIFF
--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -35,8 +35,8 @@ jobs:
         with:
           command: check
 
-  test_nightly:
-    name: Nightly tests
+  test_nightly_std:
+    name: Nightly tests std
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -49,9 +49,22 @@ jobs:
         with:
           command: test
           args: --release
-
-  test_nightly_canon:
-    name: Nightly tests
+  test_nightly_no_std:
+    name: Nightly tests no_std
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --release --no-default-features
+  test_nightly_canon_std:
+    name: Nightly tests canon std
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -64,9 +77,24 @@ jobs:
         with:
           command: test
           args: --release --features canon
-
-  test_nightly_canon_host:
-    name: Nightly tests
+      
+  test_nightly_canon_no_std:
+    name: Nightly tests canon no_std 
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --release --no-default-features --features canon
+          
+  test_nightly_canon_host_std:
+    name: Nightly tests canon_host std
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -79,6 +107,29 @@ jobs:
         with:
           command: test
           args: --release --features canon_host
+      - uses: actions-rs/cargo@v1
+        with:
+          comand: test
+          args: --release --features canon_host
+
+  test_nightly_canon_host_no_std:
+    name: Nightly tests canon_host no_std
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --release --features canon_host
+      - uses: actions-rs/cargo@v1
+        with:
+          comand: test
+          args: --release --no-default-features --features canon_host
 
   fmt:
     name: Rustfmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,10 @@ edition = "2018"
 
 [dependencies]
 lazy_static = "1.3.0"
-hades252 = { git = "https://github.com/dusk-network/hades252", tag = "v0.10.0" }
-dusk-plonk = {version = "0.3.3", features = ["trace-print"]}
+hades252 = { git = "https://github.com/dusk-network/hades252", tag = "v0.10.1", default-features = false }
+dusk-plonk = {version = "0.3", default-features = false}
+dusk-bls12_381 = {version = "0.3", default-features = false}
+dusk-jubjub = {version = "0.5", default-features = false}
 anyhow = "1.0"
 thiserror = "1.0"
 canonical = {version = "0.4", optional = true}
@@ -24,8 +26,11 @@ rand_core = "0.5"
 criterion = "0.3"
 
 [features]
+default = ["std"]
+std = ["hades252/default", "dusk-bls12_381/default", "dusk-jubjub/std"]
 canon = ["canonical", "canonical_derive", "nstack", "microkelvin", "dusk-plonk/canon"]
 canon_host = ["canon", "canonical/host"]
+
 
 [profile.dev]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ criterion = "0.3"
 [features]
 default = ["std"]
 std = ["hades252/default", "dusk-bls12_381/default", "dusk-jubjub/std"]
-canon = ["canonical", "canonical_derive", "nstack", "microkelvin", "dusk-plonk/canon"]
+canon = ["canonical", "canonical_derive", "nstack", "microkelvin", "dusk-bls12_381/canon", "dusk-jubjub/canon"]
 canon_host = ["canon", "canonical/host"]
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,13 @@ dusk-bls12_381 = {version = "0.3", default-features = false}
 dusk-jubjub = {version = "0.5", default-features = false}
 anyhow = "1.0"
 thiserror = "1.0"
-canonical = {git = "https://github.com/dusk-network/canonical", branch = "hashing_resolv", optional = true}
-canonical_derive = {git = "https://github.com/dusk-network/canonical", branch = "hashing_resolv", optional = true}
+canonical = {version = "0.4", optional = true}
+canonical_derive = {version = "0.4", optional = true}
 microkelvin = {version = "0.5", optional = true}
 nstack = {version = "0.6", optional = true}
 
 [dev-dependencies]
-canonical_host = {git = "https://github.com/dusk-network/canonical", branch = "hashing_resolv"}
+canonical_host = {version = "0.4"}
 rand = "0.7"
 rand_core = "0.5"
 criterion = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,13 @@ dusk-bls12_381 = {version = "0.3", default-features = false}
 dusk-jubjub = {version = "0.5", default-features = false}
 anyhow = "1.0"
 thiserror = "1.0"
-canonical = {version = "0.4", optional = true}
-canonical_derive = {version = "0.4", optional = true}
+canonical = {git = "https://github.com/dusk-network/canonical", branch = "hashing_resolv", optional = true}
+canonical_derive = {git = "https://github.com/dusk-network/canonical", branch = "hashing_resolv", optional = true}
 microkelvin = {version = "0.5", optional = true}
 nstack = {version = "0.6", optional = true}
 
 [dev-dependencies]
-canonical_host = "0.4"
+canonical_host = {git = "https://github.com/dusk-network/canonical", branch = "hashing_resolv"}
 rand = "0.7"
 rand_core = "0.5"
 criterion = "0.3"

--- a/src/cipher/cipher.rs
+++ b/src/cipher/cipher.rs
@@ -8,7 +8,7 @@
 use canonical::Canon;
 #[cfg(feature = "canon")]
 use canonical_derive::Canon;
-use dusk_plonk::jubjub::AffinePoint;
+use dusk_jubjub::JubJubAffine;
 use dusk_plonk::prelude::*;
 use hades252::{ScalarStrategy, Strategy, WIDTH};
 
@@ -96,6 +96,7 @@ pub struct PoseidonCipher {
     cipher: [BlsScalar; CIPHER_SIZE],
 }
 
+#[cfg(feature = "std")]
 impl PoseidonCipher {
     /// [`PoseidonCipher`] constructor
     pub fn new(cipher: [BlsScalar; CIPHER_SIZE]) -> Self {
@@ -155,7 +156,7 @@ impl PoseidonCipher {
     /// The message size will be truncated to [`MESSAGE_CAPACITY`] bits
     pub fn encrypt(
         message: &[BlsScalar],
-        secret: &AffinePoint,
+        secret: &JubJubAffine,
         nonce: &BlsScalar,
     ) -> Self {
         let zero = BlsScalar::zero();
@@ -187,7 +188,7 @@ impl PoseidonCipher {
     /// Will return `None` if the decryption fails.
     pub fn decrypt(
         &self,
-        secret: &AffinePoint,
+        secret: &JubJubAffine,
         nonce: &BlsScalar,
     ) -> Result<[BlsScalar; MESSAGE_CAPACITY], CipherError> {
         let zero = BlsScalar::zero();
@@ -219,7 +220,7 @@ impl PoseidonCipher {
 
     /// Returns the initial state of the encryption
     pub fn initial_state(
-        secret: &AffinePoint,
+        secret: &JubJubAffine,
         nonce: BlsScalar,
     ) -> [BlsScalar; WIDTH] {
         [

--- a/src/cipher/cipher.rs
+++ b/src/cipher/cipher.rs
@@ -16,6 +16,7 @@ use super::{
     CIPHER_BYTES_SIZE, CIPHER_SIZE, ENCRYPTED_DATA_SIZE, MESSAGE_CAPACITY,
 };
 
+#[cfg(feature = "std")]
 pub use super::CipherError;
 
 /// ```ignore

--- a/src/cipher/error.rs
+++ b/src/cipher/error.rs
@@ -4,6 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+#![cfg(feature = "std")]
 use thiserror::Error;
 
 /// Error definitions for the decription process

--- a/src/cipher/mod.rs
+++ b/src/cipher/mod.rs
@@ -4,6 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+#![cfg(feature = "std")]
 pub use cipher::PoseidonCipher;
 pub use error::CipherError;
 

--- a/src/cipher/mod.rs
+++ b/src/cipher/mod.rs
@@ -4,8 +4,8 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-#![cfg(feature = "std")]
 pub use cipher::PoseidonCipher;
+#[cfg(feature = "std")]
 pub use error::CipherError;
 
 /// Maximum number of scalars allowed per message
@@ -26,11 +26,13 @@ pub const ENCRYPTED_DATA_SIZE: usize = CIPHER_SIZE * 32;
 /// [`PoseidonCipher`] definition
 pub mod cipher;
 
+#[cfg(feature = "std")]
 /// Error definition for the cipher generation process
 pub mod error;
 
 #[cfg(test)]
 mod tests;
 
+#[cfg(feature = "std")]
 /// Plonk gadget for Poseidon encryption
 pub mod zk;

--- a/src/cipher/tests.rs
+++ b/src/cipher/tests.rs
@@ -4,6 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+#![cfg(feature = "std")]
 use super::{PoseidonCipher, CIPHER_SIZE, MESSAGE_CAPACITY};
 use anyhow::Result;
 use dusk_plonk::jubjub::{AffinePoint, Fr, GENERATOR};

--- a/src/cipher/zk.rs
+++ b/src/cipher/zk.rs
@@ -4,6 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+#![cfg(feature = "std")]
 use super::{PoseidonCipher, CIPHER_SIZE, MESSAGE_CAPACITY};
 use dusk_plonk::constraint_system::ecc::Point;
 use dusk_plonk::prelude::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,13 +8,16 @@
 #![feature(min_const_generics)]
 #![feature(external_doc)]
 #![doc(include = "../README.md")]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 /// Encryption and decryption implementation over a Poseidon cipher
 pub mod cipher;
+#[cfg(feature = "std")]
 /// Module containing a fixed-length Poseidon hash implementation
 pub mod perm_uses;
+#[cfg(feature = "std")]
 /// Reference implementation for the Poseidon Sponge hash function
 pub mod sponge;
 /// The module handling posedion-trees.
-#[cfg(feature = "canon")]
+#[cfg(all(feature = "canon", feature = "std"))]
 pub mod tree;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,5 +19,5 @@ pub mod perm_uses;
 /// Reference implementation for the Poseidon Sponge hash function
 pub mod sponge;
 /// The module handling posedion-trees.
-#[cfg(all(feature = "canon", feature = "std"))]
+#[cfg(feature = "canon")]
 pub mod tree;

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -88,7 +88,6 @@ where
     }
 }
 
-#[cfg(feature = "std")]
 impl<L, A, S, const DEPTH: usize> PoseidonTree<L, A, S, DEPTH>
 where
     L: PoseidonLeaf<S>,
@@ -101,7 +100,7 @@ where
 
         Self { inner }
     }
-
+    #[cfg(feature = "std")]
     /// Append a leaf to the tree. Return the index of the appended leaf.
     ///
     /// Will call the `tree_pos_mut` implementation of the leaf to
@@ -125,14 +124,14 @@ where
 
         Ok(size)
     }
-
+    #[cfg(feature = "std")]
     /// Fetch, remove and return the last inserted leaf, if present.
     pub fn pop(&mut self) -> Result<Option<L>> {
         self.inner
             .pop()
             .map_err(|e| anyhow!("Error pop from the tree: {:?}", e))
     }
-
+    #[cfg(feature = "std")]
     /// Fetch a leaf on a provided index.
     pub fn get(&self, n: usize) -> Result<Option<L>> {
         self.inner
@@ -142,7 +141,7 @@ where
                 anyhow!("Error fetching the Nth item from the tree: {:?}", e)
             })
     }
-
+    #[cfg(feature = "std")]
     /// Return a full merkle opening for this poseidon tree for a given index.
     pub fn branch(&self, n: usize) -> Result<Option<PoseidonBranch<DEPTH>>> {
         let branch = self.inner.nth::<DEPTH>(n as u64).map_err(|e| {
@@ -154,12 +153,12 @@ where
             None => Ok(None),
         }
     }
-
+    #[cfg(feature = "std")]
     /// Return the current root/state of the tree.
     pub fn root(&self) -> Result<BlsScalar> {
         self.branch(0).map(|b| b.unwrap_or_default().root())
     }
-
+    #[cfg(feature = "std")]
     /// Iterates over the tree, provided its annotation implements [`PoseidonWalkableAnnotation`]
     pub fn iter_walk<D: Clone>(
         &self,

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -20,6 +20,7 @@ pub use branch::{PoseidonBranch, PoseidonLevel};
 mod annotation;
 mod branch;
 
+#[cfg(feature = "std")]
 /// Zero-Knowledge implementations for the poseidon tree
 pub mod zk;
 
@@ -171,6 +172,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 /// Main iterator of the poseidon tree.
 ///
 /// Depends on an implementation of `PoseidonWalkableAnnotation` for the tree annotation
@@ -192,6 +194,7 @@ where
     data: D,
 }
 
+#[cfg(feature = "std")]
 impl<L, A, S, D, const DEPTH: usize> PoseidonTreeIterator<L, A, S, D, DEPTH>
 where
     L: PoseidonLeaf<S>,
@@ -217,6 +220,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<L, A, S, D, const DEPTH: usize> Iterator
     for PoseidonTreeIterator<L, A, S, D, DEPTH>
 where

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -87,6 +87,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<L, A, S, const DEPTH: usize> PoseidonTree<L, A, S, DEPTH>
 where
     L: PoseidonLeaf<S>,


### PR DESCRIPTION
We need to be able to have the Structure definitions that will be used in our contracts from this repo avaliable in `no_std` envoirments. 

Therefore, this featuring addition, enables the only possible way to make that happen with the minimal additions to the `no_std` env.

I would not go into this direction. But that requires a bit of reasoning on which will be the approach of implementing `PoseidonLeaf` trait in our contracts.