### PR TITLE
Update `plonk` from `0.6` to `0.7`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update `dusk-plonk` from `0.6` to `0.7` #119
-- Update `dusk-hades` from `0.14` to `0.15.0-pre` #119
+- Update `dusk-hades` from `0.14` to `0.15` #119
 
 ## [0.19.0] - 2021-03-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update `dusk-plonk` from `0.6` to `0.7` #119
+- Update `dusk-hades` to unreleased version #119
+
 ## [0.19.0] - 2021-03-11
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update `dusk-plonk` from `0.6` to `0.7` #119
-- Update `dusk-hades` to unreleased version #119
+- Update `dusk-hades` from `0.14` to `0.15.0-pre` #119
 
 ## [0.19.0] - 2021-03-11
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-poseidon"
-version = "0.19.0"
+version = "0.20.0-pre.0"
 authors = [
   "zer0 <matteo@dusk.network>", "vlopes11 <victor@dusk.network>", "CPerezz <carlos@dusk.network>", "Kristoffer Ström <kristoffer@dusk.network>"
 ]
@@ -15,13 +15,13 @@ repository = "https://github.com/dusk-network/poseidon252"
 dusk-bls12_381 = {version = "0.6", default-features = false}
 dusk-jubjub = {version = "0.8", default-features = false}
 dusk-bytes = "0.1"
-dusk-hades = { version = "0.14", default-features = false }
+dusk-hades = { version = "0.15.0-pre", default-features = false }
 canonical = {version = "0.5", optional = true}
 canonical_derive = {version = "0.5", optional = true}
 microkelvin = {version = "0.6", optional = true}
 nstack = {version = "0.7", optional = true}
 
-dusk-plonk = {version="0.6", default-features = false, optional = true}
+dusk-plonk = {version="0.7.0-pre", default-features = false, optional = true}
 anyhow = { version = "1.0", optional = true }
 thiserror = { version = "1.0", optional = true }
 

--- a/src/tree/zk.rs
+++ b/src/tree/zk.rs
@@ -87,7 +87,11 @@ mod tests {
             let leaf = composer.add_input(leaf);
 
             let root_p = merkle_opening::<DEPTH>(composer, &branch, leaf);
-            composer.constrain_to_constant(root_p, BlsScalar::zero(), Some(-root));
+            composer.constrain_to_constant(
+                root_p,
+                BlsScalar::zero(),
+                Some(-root),
+            );
         };
 
         let label = b"opening_gadget";


### PR DESCRIPTION
This update will also trigger a dusk-hades update. The version has not
been released yet, so it will temporarily point to the unreleased branch

Resolves #119