### PR TITLE
Merkle opening constant circuit description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `dusk-plonk` from `0.6` to `0.7` #119
 - Update `dusk-hades` from `0.14` to `0.15` #119
 
+### Fixed
+
+- Merkle Opening constant circuit description [#122]
+
 ## [0.19.0] - 2021-03-11
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-poseidon"
-version = "0.20.0-pre.0"
+version = "0.20.0-pre.1"
 authors = [
   "zer0 <matteo@dusk.network>", "vlopes11 <victor@dusk.network>", "CPerezz <carlos@dusk.network>", "Kristoffer Ström <kristoffer@dusk.network>"
 ]

--- a/README.md
+++ b/README.md
@@ -140,10 +140,7 @@ fn main() -> Result<()> {
             let branch = tree.branch(n).unwrap().unwrap();
             let root = tree.root().unwrap();
 
-            let leaf = BlsScalar::from(n as u64);
-            let leaf = composer.add_input(leaf);
-
-            let root_p = merkle_opening::<DEPTH>(composer, &branch, leaf);
+            let root_p = merkle_opening::<DEPTH>(composer, &branch);
             composer.constrain_to_constant(root_p, BlsScalar::zero(), Some(-root));
         };
 

--- a/src/tree/branch.rs
+++ b/src/tree/branch.rs
@@ -26,8 +26,19 @@ pub struct PoseidonLevel {
 impl PoseidonLevel {
     /// Represents the offset of a node for a given path produced by a branch
     /// in a merkle opening
-    pub fn offset(&self) -> u64 {
+    ///
+    /// The first position in a level set is represented as offset `1` because internally the hades
+    /// permutation preprend the bitflags for merkle opening consistency
+    pub const fn offset(&self) -> u64 {
         self.offset
+    }
+
+    /// Represents the current level offset as a bitflag
+    ///
+    /// The LSB (least significant bit) represents the offset `1`. Any increment on the offset will
+    /// left shift this flag by `1`.
+    pub const fn offset_flag(&self) -> u64 {
+        1 << (self.offset - 1)
     }
 }
 

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -79,10 +79,7 @@
 //!         let branch = tree.branch(n).unwrap().unwrap();
 //!         let root = tree.root().unwrap();
 //!
-//!         let leaf = BlsScalar::from(n as u64);
-//!         let leaf = composer.add_input(leaf);
-//!
-//!         let root_p = merkle_opening::<DEPTH>(composer, &branch, leaf);
+//!         let root_p = merkle_opening::<DEPTH>(composer, &branch);
 //!         composer.constrain_to_constant(root_p, BlsScalar::zero(), Some(-root));
 //!     };
 //!

--- a/src/tree/tests.rs
+++ b/src/tree/tests.rs
@@ -13,12 +13,23 @@ use canonical_host::MemStore;
 use core::borrow::Borrow;
 use dusk_bls12_381::BlsScalar;
 use dusk_hades::{ScalarStrategy, Strategy};
+use rand::{CryptoRng, RngCore};
 
 #[derive(Debug, Default, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Canon)]
 pub struct MockLeaf {
     s: BlsScalar,
     pub pos: u64,
     pub expiration: u64,
+}
+
+impl MockLeaf {
+    pub fn random<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
+        let s = BlsScalar::random(rng);
+        let pos = 0;
+        let expiration = rng.next_u64();
+
+        Self { s, pos, expiration }
+    }
 }
 
 impl From<u64> for MockLeaf {

--- a/src/tree/zk.rs
+++ b/src/tree/zk.rs
@@ -12,7 +12,6 @@ use dusk_plonk::prelude::*;
 pub fn merkle_opening<const DEPTH: usize>(
     composer: &mut StandardComposer,
     branch: &PoseidonBranch<DEPTH>,
-    leaf: Variable,
 ) -> Variable {
     // Generate and constraint zero.
     let zero = composer.add_witness_to_circuit_description(BlsScalar::zero());
@@ -24,21 +23,61 @@ pub fn merkle_opening<const DEPTH: usize>(
     // For every level, replace the level offset with needle,
     // permutate the level and set the needle to the next level
     // to the poseidon result of the permutation
-    branch.as_ref().iter().fold(leaf, |needle, level| {
-        let offset = level.offset() as usize;
+    branch.as_ref().iter().for_each(|level| {
+        // Create the bits representation of the offset as witness
+        let offset_flag = level.offset_flag();
+        let mut sum = zero;
+        let mut offset_bits = [zero; dusk_hades::WIDTH - 1];
+        offset_bits.iter_mut().fold(1, |mask, bit| {
+            *bit = composer
+                .add_input(BlsScalar::from((offset_flag & mask).min(1)));
 
-        level.as_ref().iter().enumerate().for_each(|(i, l)| {
-            if i != offset {
-                perm[i] = composer.add_input(*l);
-            }
+            sum = composer.add(
+                (BlsScalar::one(), sum),
+                (BlsScalar::one(), *bit),
+                BlsScalar::zero(),
+                None,
+            );
+
+            mask << 1
         });
+        composer.constrain_to_constant(sum, BlsScalar::one(), None);
+
+        let leaf = composer.add_input(**level);
+        level
+            .as_ref()
+            .iter()
+            .zip(perm.iter_mut())
+            .enumerate()
+            .for_each(|(i, (l, p))| {
+                *p = composer.add_input(*l);
+
+                if i > 0 {
+                    let b = offset_bits[i - 1];
+
+                    let a = composer.mul(
+                        BlsScalar::one(),
+                        b,
+                        *p,
+                        BlsScalar::zero(),
+                        None,
+                    );
+
+                    let b = composer.mul(
+                        BlsScalar::one(),
+                        b,
+                        leaf,
+                        BlsScalar::zero(),
+                        None,
+                    );
+
+                    composer.assert_equal(a, b);
+                }
+            });
 
         root = perm[1];
-        perm[offset] = needle;
-
         let mut h = GadgetStrategy::new(composer);
         h.perm(&mut perm);
-        perm[1]
     });
 
     root
@@ -47,68 +86,98 @@ pub fn merkle_opening<const DEPTH: usize>(
 #[cfg(test)]
 mod tests {
     use crate::tree::tests::MockLeaf;
-    use crate::tree::{merkle_opening, PoseidonAnnotation, PoseidonTree};
-    use anyhow::Result;
+    use crate::tree::{self, PoseidonAnnotation, PoseidonBranch, PoseidonTree};
     use canonical_host::MemStore;
+    use dusk_plonk::circuit;
+    use dusk_plonk::prelude::Error as PlonkError;
     use dusk_plonk::prelude::*;
+    use rand::rngs::StdRng;
+    use rand::SeedableRng;
+    use rand::{CryptoRng, RngCore};
 
-    #[test]
-    fn tree_merkle_opening() -> Result<()> {
-        const DEPTH: usize = 17;
+    const DEPTH: usize = 17;
+    const CAPACITY: usize = 1 << 15;
+    type Tree = PoseidonTree<MockLeaf, PoseidonAnnotation, MemStore, DEPTH>;
 
-        let pub_params =
-            PublicParameters::setup(1 << 15, &mut rand::thread_rng())?;
-        let (ck, ok) = pub_params.trim(1 << 15)?;
+    struct MerkleOpeningCircuit {
+        branch: PoseidonBranch<DEPTH>,
+    }
 
-        let mut tree: PoseidonTree<
-            MockLeaf,
-            PoseidonAnnotation,
-            MemStore,
-            DEPTH,
-        > = PoseidonTree::new();
+    impl MerkleOpeningCircuit {
+        pub fn random<R: RngCore + CryptoRng>(
+            rng: &mut R,
+            tree: &mut Tree,
+        ) -> Self {
+            let leaf = MockLeaf::random(rng);
+            let pos = tree
+                .push(leaf.clone())
+                .expect("Failed to append to the tree");
 
-        for i in 0..1024 {
-            let l = MockLeaf::from(i as u64);
-            tree.push(l).unwrap();
+            let branch = tree
+                .branch(pos)
+                .expect("Failed to read the tree for the branch")
+                .expect("Failed to fetch the branch of the created leaf from the tree");
+
+            Self { branch }
         }
 
-        let gadget_tester = |composer: &mut StandardComposer,
-                             tree: &PoseidonTree<
-            MockLeaf,
-            PoseidonAnnotation,
-            MemStore,
-            DEPTH,
-        >,
-                             n: usize| {
-            let branch = tree.branch(n).unwrap().unwrap();
-            let root = tree.root().unwrap();
+        pub fn public_inputs(&self) -> Vec<PublicInputValue> {
+            vec![(*self.branch.root()).into()]
+        }
+    }
 
-            let leaf = BlsScalar::from(n as u64);
-            let leaf = composer.add_input(leaf);
+    impl Circuit for MerkleOpeningCircuit {
+        const CIRCUIT_ID: [u8; 32] = [0xff; 32];
 
-            let root_p = merkle_opening::<DEPTH>(composer, &branch, leaf);
+        fn gadget(
+            &mut self,
+            composer: &mut StandardComposer,
+        ) -> Result<(), PlonkError> {
+            let root = self.branch.root();
+            let root_p = tree::merkle_opening::<DEPTH>(composer, &self.branch);
+
             composer.constrain_to_constant(
                 root_p,
                 BlsScalar::zero(),
                 Some(-root),
             );
-        };
 
-        let label = b"opening_gadget";
-
-        for i in [0, 567, 1023].iter() {
-            let mut prover = Prover::new(label);
-            gadget_tester(prover.mut_cs(), &tree, *i);
-            prover.preprocess(&ck)?;
-            let proof = prover.prove(&ck)?;
-
-            let mut verifier = Verifier::new(label);
-            gadget_tester(verifier.mut_cs(), &tree, *i);
-            verifier.preprocess(&ck)?;
-            let pi = verifier.mut_cs().construct_dense_pi_vec();
-            verifier.verify(&proof, &ok, &pi).unwrap();
+            Ok(())
         }
 
-        Ok(())
+        fn padded_circuit_size(&self) -> usize {
+            CAPACITY
+        }
+    }
+
+    #[test]
+    fn tree_merkle_opening() {
+        let mut rng = StdRng::seed_from_u64(0xbeef);
+        let pp = PublicParameters::setup(CAPACITY, &mut rng).unwrap();
+        let label = b"dusk-network";
+
+        let mut tree = Tree::default();
+        let mut circuit = MerkleOpeningCircuit::random(&mut rng, &mut tree);
+        let (pk, vd) = circuit.compile(&pp).expect("Failed to compile circuit");
+
+        let mut tree = Tree::default();
+        for _ in 0..13 {
+            let mut circuit = MerkleOpeningCircuit::random(&mut rng, &mut tree);
+
+            let proof = circuit
+                .gen_proof(&pp, &pk, label)
+                .expect("Failed to generate proof");
+            let pi = circuit.public_inputs();
+
+            circuit::verify_proof(
+                &pp,
+                vd.key(),
+                &proof,
+                pi.as_slice(),
+                vd.pi_pos(),
+                label,
+            )
+            .expect("Proof verification failed");
+        }
     }
 }


### PR DESCRIPTION
PLONK requires the circuit description + witness indexes to be constant
so the same verifier data can be reused to check different proofs.

The previous implementation contained an optimization that swaps the
witness index to reduce the number of gates.

This optimization may lead to inconsistencies when reusing verifier keys
because the verification will depend on the disposition of the witness
data, and this is undesirable.

Resolves #122