### PR TITLE
Refactor error module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Updated `error` module to be simpler and no_std friendly. [#132](https://github.com/dusk-network/poseidon252/issues/132)
+
+### Removed
+- Removed `anyhow` and `thiserror` from deps. [#132](https://github.com/dusk-network/poseidon252/issues/132)
+
 ## [0.20.0] - 2021-04-06
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,6 @@ canonical_derive = {version = "0.6", optional = true}
 microkelvin = {version = "0.7", optional = true}
 nstack = {version = "0.7", optional = true}
 dusk-plonk = {version="0.8.0-rc.1", default-features = false, optional = true}
-anyhow = { version = "1.0", optional = true }
-thiserror = { version = "1.0", optional = true }
 
 [dev-dependencies]
 canonical_host = "0.5"
@@ -38,8 +36,6 @@ std = [
     "dusk-bls12_381/default",
     "dusk-jubjub/std",
     "dusk-plonk",
-    "anyhow",
-    "thiserror"
 ]
 canon = [
     "dusk-bls12_381/canon",

--- a/src/cipher/cipher.rs
+++ b/src/cipher/cipher.rs
@@ -138,7 +138,7 @@ impl PoseidonCipher {
         &self,
         secret: &JubJubAffine,
         nonce: &BlsScalar,
-    ) -> Result<[BlsScalar; MESSAGE_CAPACITY], Error<()>> {
+    ) -> Result<[BlsScalar; MESSAGE_CAPACITY], Error> {
         let zero = BlsScalar::zero();
         let mut strategy = ScalarStrategy::new();
 

--- a/src/cipher/tests.rs
+++ b/src/cipher/tests.rs
@@ -51,7 +51,7 @@ fn sanity() {
 }
 
 #[test]
-fn encrypt() -> Result<(), Error<()>> {
+fn encrypt() -> Result<(), Error> {
     let (message, secret, nonce) = gen();
 
     let cipher = PoseidonCipher::encrypt(&message, &secret, &nonce);
@@ -63,7 +63,7 @@ fn encrypt() -> Result<(), Error<()>> {
 }
 
 #[test]
-fn single_bit() -> Result<(), Error<()>> {
+fn single_bit() -> Result<(), Error> {
     let (_, secret, nonce) = gen();
     let message = BlsScalar::random(&mut OsRng);
 
@@ -76,7 +76,7 @@ fn single_bit() -> Result<(), Error<()>> {
 }
 
 #[test]
-fn overflow() -> Result<(), Error<()>> {
+fn overflow() -> Result<(), Error> {
     let (_, secret, nonce) = gen();
     let message =
         [BlsScalar::random(&mut OsRng); PoseidonCipher::capacity() + 1];
@@ -99,7 +99,7 @@ fn wrong_key_fail() {
 }
 
 #[test]
-fn bytes() -> Result<(), Error<()>> {
+fn bytes() -> Result<(), Error> {
     let (message, secret, nonce) = gen();
 
     let cipher = PoseidonCipher::encrypt(&message, &secret, &nonce);

--- a/src/cipher/zk.rs
+++ b/src/cipher/zk.rs
@@ -111,7 +111,6 @@ pub fn decrypt(
 #[cfg(test)]
 mod tests {
     use crate::cipher::{decrypt, encrypt, PoseidonCipher};
-    use anyhow::Result;
     use dusk_bls12_381::BlsScalar;
     use dusk_jubjub::{dhke, JubJubExtended, GENERATOR_EXTENDED};
     use dusk_plonk::constraint_system::ecc::scalar_mul::variable_base::variable_base_scalar_mul;
@@ -119,7 +118,7 @@ mod tests {
     use rand_core::OsRng;
 
     #[test]
-    fn gadget() -> Result<()> {
+    fn gadget() -> Result<(), Error> {
         // Generate a secret and a public key for Bob
         let bob_secret = JubJubScalar::random(&mut OsRng);
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,9 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use core::fmt;
-#[cfg(feature = "std")]
-use std::fmt::{Display, Result};
+use core::fmt::{self, Display, Result};
 
 /// Poseidon error variants
 #[derive(Clone, Debug)]
@@ -25,7 +23,6 @@ pub enum Error {
     CipherDecryptionFailed,
 }
 
-#[cfg(feature = "std")]
 impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result {
         write!(f, "Dusk-Poseidon Error: {:?}", &self)

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,41 +5,29 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use core::fmt;
-
 #[cfg(feature = "std")]
-use std::{error as std_error, fmt as std_fmt};
+use std::fmt::{Display, Result};
 
 /// Poseidon error variants
-#[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub enum Error<E: fmt::Debug> {
+#[derive(Clone, Debug)]
+pub enum Error {
     /// Error pushing to the poseidon tree
-    TreePushFailed(E),
+    TreePushFailed,
     /// Error on pop of the tree
-    TreePopFailed(E),
+    TreePopFailed,
     /// Error fetching the Nth item from the tree
-    TreeGetFailed(E),
+    TreeGetFailed,
+    /// Failed to obtain a Branch from a tree.
+    TreeBranchFailed,
+    /// Failed to obtain an Iterator from a tree.
+    TreeIterFailed,
     /// Decryption failed for the provided secret+nonce
     CipherDecryptionFailed,
-    /// Failed to obtain an Iterator from a tree.
-    TreeIterFailed(E),
 }
 
 #[cfg(feature = "std")]
-impl<E: fmt::Debug> std_fmt::Display for Error<E> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std_fmt::Result {
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result {
         write!(f, "Dusk-Poseidon Error: {:?}", &self)
-    }
-}
-
-#[cfg(feature = "std")]
-impl<E: 'static + fmt::Debug + std_error::Error> std_error::Error for Error<E> {
-    fn source(&self) -> Option<&(dyn std_error::Error + 'static)> {
-        match &self {
-            Self::TreePushFailed(e) => Some(e),
-            Self::TreePopFailed(e) => Some(e),
-            Self::TreeGetFailed(e) => Some(e),
-            Self::TreeIterFailed(e) => Some(e),
-            _ => None,
-        }
     }
 }

--- a/src/sponge/sponge.rs
+++ b/src/sponge/sponge.rs
@@ -176,7 +176,6 @@ pub fn sponge_gadget(
 #[cfg(feature = "std")]
 mod tests {
     use super::*;
-    use anyhow::Result;
     use dusk_hades::WIDTH;
     use rand_core::OsRng;
 
@@ -225,7 +224,7 @@ mod tests {
     }
 
     #[test]
-    fn sponge_gadget_width_3() -> Result<()> {
+    fn sponge_gadget_width_3() -> Result<(), Error> {
         // Setup OG params.
         let public_parameters = PublicParameters::setup(CAPACITY, &mut OsRng)?;
         let (ck, vk) = public_parameters.trim(CAPACITY)?;
@@ -249,7 +248,7 @@ mod tests {
     }
 
     #[test]
-    fn sponge_gadget_hades_width() -> Result<()> {
+    fn sponge_gadget_hades_width() -> Result<(), Error> {
         // Setup OG params.
         let public_parameters = PublicParameters::setup(CAPACITY, &mut OsRng)?;
         let (ck, vk) = public_parameters.trim(CAPACITY)?;
@@ -273,7 +272,7 @@ mod tests {
     }
 
     #[test]
-    fn sponge_gadget_width_15() -> Result<()> {
+    fn sponge_gadget_width_15() -> Result<(), Error> {
         // Setup OG params.
         let public_parameters = PublicParameters::setup(1 << 17, &mut OsRng)?;
         let (ck, vk) = public_parameters.trim(1 << 17)?;


### PR DESCRIPTION
- Removes unused std-compatibility for the `Error` struct.
- Removes the usage of `anyhow` and `thiserror` in
tests and lib.
- Adds two new variants for the `Error` called `TreeIterFailed`
and `TreeBranchFailed`.

Resolves: #132