### PR TITLE
Change the feature requirements of the crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Changed featureset config for the crate. [#138](https://github.com/dusk-network/poseidon252/issues/138)
 - Updated `error` module to be simpler and no_std friendly. [#132](https://github.com/dusk-network/poseidon252/issues/132)
 
 ### Removed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,15 +15,14 @@ repository = "https://github.com/dusk-network/poseidon252"
 dusk-bls12_381 = {version = "0.8.0-rc.0", default-features = false}
 dusk-jubjub = {version = "0.10.0-rc.0", default-features = false}
 dusk-bytes = "0.1"
-dusk-hades = { version = "0.16.0-rc.0", default-features = false }
+dusk-hades = "0.16.0-rc.0"
 canonical = {version = "0.6", optional = true}
 canonical_derive = {version = "0.6", optional = true}
 microkelvin = {version = "0.7.1", optional = true}
 nstack = {version = "0.8", optional = true}
-dusk-plonk = {version="0.8.0-rc.1", default-features = false, optional = true}
+dusk-plonk = {version="0.8.0-rc.1", default-features = false, features = ["alloc"]}
 
 [dev-dependencies]
-canonical_host = "0.5"
 rand_core = {version="0.6", default-features=false}
 criterion = "0.3"
 
@@ -35,7 +34,6 @@ std = [
     "dusk-hades/plonk-std",
     "dusk-bls12_381/default",
     "dusk-jubjub/std",
-    "dusk-plonk",
 ]
 canon = [
     "dusk-bls12_381/canon",

--- a/README.md
+++ b/README.md
@@ -69,10 +69,8 @@ majority of the configurations that the user may need:
 ### Zero Knowledge Merkle Opening Proof example:
 
 ```rust
-#[cfg(all(feature = "canon", feature = "std"))]
+#[cfg(feature = "canon")]
 {
-
-use anyhow::Result;
 use canonical_derive::Canon;
 use dusk_plonk::prelude::*;
 use dusk_poseidon::tree::{PoseidonAnnotation, PoseidonLeaf, PoseidonTree, merkle_opening};
@@ -116,7 +114,7 @@ impl PoseidonLeaf for DataLeaf {
     }
 }
 
-fn main() -> Result<()> {
+fn main() -> Result<(), Error> {
     // Create the ZK keys
     let pub_params = PublicParameters::setup(1 << 15, &mut OsRng)?;
     let (ck, ok) = pub_params.trim(1 << 15)?;

--- a/src/cipher/mod.rs
+++ b/src/cipher/mod.rs
@@ -90,10 +90,6 @@ mod cipher;
 #[cfg(test)]
 mod tests;
 
-#[cfg(feature = "std")]
 mod zk;
-
 pub use cipher::PoseidonCipher;
-
-#[cfg(feature = "std")]
 pub use zk::{decrypt, encrypt};

--- a/src/cipher/zk.rs
+++ b/src/cipher/zk.rs
@@ -210,7 +210,7 @@ mod tests {
         );
         verifier.preprocess(&ck)?;
 
-        assert!(verifier.verify(&proof, &vk, &vec![]).is_ok());
+        assert!(verifier.verify(&proof, &vk, &[BlsScalar::zero()]).is_ok());
 
         Ok(())
     }

--- a/src/sponge/mod.rs
+++ b/src/sponge/mod.rs
@@ -6,6 +6,5 @@
 
 mod sponge;
 
-#[cfg(feature = "std")]
 pub use sponge::sponge_gadget as gadget;
 pub use sponge::sponge_hash as hash;

--- a/src/sponge/sponge.rs
+++ b/src/sponge/sponge.rs
@@ -290,7 +290,6 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(feature = "std")]
     #[test]
     fn sponge_hash_test() {
         use dusk_bytes::ParseHexStr;

--- a/src/sponge/sponge.rs
+++ b/src/sponge/sponge.rs
@@ -7,13 +7,9 @@
 //! Sponge hash and gadget definition
 
 use dusk_bls12_381::BlsScalar;
-use dusk_hades::{ScalarStrategy, Strategy, WIDTH};
-
-#[cfg(feature = "std")]
-use dusk_plonk::prelude::*;
-
-#[cfg(feature = "std")]
 use dusk_hades::GadgetStrategy;
+use dusk_hades::{ScalarStrategy, Strategy, WIDTH};
+use dusk_plonk::prelude::*;
 
 /// The `hash` function takes an arbitrary number of Scalars and returns the
 /// hash, using the `Hades` ScalarStragegy.
@@ -87,7 +83,6 @@ pub fn sponge_hash(messages: &[BlsScalar]) -> BlsScalar {
     state[1]
 }
 
-#[cfg(feature = "std")]
 /// Mirror the implementation of [`sponge_hash`] inside of a PLONK circuit.
 ///
 /// The circuit will be defined by the length of `messages`. This means that a
@@ -172,8 +167,8 @@ pub fn sponge_gadget(
     state[1]
 }
 
-#[cfg(test)]
 #[cfg(feature = "std")]
+#[cfg(test)]
 mod tests {
     use super::*;
     use dusk_hades::WIDTH;
@@ -295,6 +290,7 @@ mod tests {
         Ok(())
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn sponge_hash_test() {
         use dusk_bytes::ParseHexStr;

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -13,7 +13,6 @@
 //! ```rust
 //! #[cfg(feature = "std")]
 //! {
-//! use anyhow::Result;
 //! use canonical_derive::Canon;
 //! use dusk_plonk::prelude::*;
 //! use dusk_poseidon::tree::{merkle_opening, PoseidonAnnotation, PoseidonLeaf, PoseidonTree};
@@ -57,7 +56,7 @@
 //!     }
 //! }
 //!
-//! fn main() -> Result<()> {
+//! fn main() -> Result<(), Error> {
 //!     // Create the ZK keys
 //!     let pub_params = PublicParameters::setup(1 << 15, &mut OsRng)?;
 //!     let (ck, ok) = pub_params.trim(1 << 15)?;

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -11,7 +11,6 @@
 //! ### Example
 //!
 //! ```rust
-//! #[cfg(feature = "std")]
 //! {
 //! use canonical_derive::Canon;
 //! use dusk_plonk::prelude::*;
@@ -107,8 +106,6 @@ mod annotation;
 mod branch;
 mod leaf;
 mod tree;
-
-#[cfg(feature = "std")]
 mod zk;
 
 pub use annotation::{
@@ -117,6 +114,4 @@ pub use annotation::{
 pub use branch::{PoseidonBranch, PoseidonLevel};
 pub use leaf::PoseidonLeaf;
 pub use tree::PoseidonTree;
-
-#[cfg(feature = "std")]
 pub use zk::merkle_opening;

--- a/tests/block_height.rs
+++ b/tests/block_height.rs
@@ -4,6 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+#![cfg(feature = "canon")]
 #![cfg(test)]
 use canonical_derive::Canon;
 use core::borrow::Borrow;

--- a/tests/max_annotation.rs
+++ b/tests/max_annotation.rs
@@ -4,6 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+#![cfg(feature = "canon")]
 use canonical_derive::Canon;
 use core::borrow::Borrow;
 use dusk_bls12_381::BlsScalar;

--- a/tests/walkable_iter.rs
+++ b/tests/walkable_iter.rs
@@ -4,6 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+#![cfg(feature = "canon")]
 use canonical_derive::Canon;
 use core::borrow::Borrow;
 use dusk_bls12_381::BlsScalar;

--- a/tests/zk.rs
+++ b/tests/zk.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
+
 #![cfg(feature = "canon")]
 
 mod max_annotation;

--- a/tests/zk.rs
+++ b/tests/zk.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
+#![cfg(feature = "canon")]
 
 mod max_annotation;
 use dusk_plonk::circuit;


### PR DESCRIPTION
The requirements were not in-line with the dependencies that we
are using and it's feature sets.

Therefore, we no longer need to restrict the zk part of things
to `std` and instead can always have it enabled via using `alloc`
by default.


Resolves: #138