### PR TITLE
Remove Microkelvin requirements from tree traits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove `PoseidonWalkableIterator` and `PoseidonWalkableAnnotation` [#125](https://github.com/dusk-network/poseidon252/issues/125)
 - Remove `canon_host` feature checks from CI [#136](https://github.com/dusk-network/poseidon252/issues/136)
 - Remove `anyhow` and `thiserror` usage [#132](https://github.com/dusk-network/poseidon252/issues/132)
+- Remove `microkelvin` requirements from Tree [#146](https://github.com/dusk-network/Poseidon252/issues/146)
 
 ## [0.20.0] - 2021-04-06
 

--- a/src/tree/annotation/mod.rs
+++ b/src/tree/annotation/mod.rs
@@ -8,7 +8,8 @@ use crate::tree::PoseidonLeaf;
 use canonical::Canon;
 use core::borrow::Borrow;
 use dusk_bls12_381::BlsScalar;
-use microkelvin::{Annotation, Cardinality};
+use microkelvin::{Annotation, Cardinality, Combine};
+use nstack::NStack;
 
 mod max;
 mod poseidon;
@@ -19,19 +20,13 @@ pub use poseidon::PoseidonAnnotation;
 /// Any structure that implements this trait is guaranteed to be compatible
 /// as a poseidon tree annotation
 pub trait PoseidonTreeAnnotation<L>:
-    Default + Canon + Annotation<L> + Borrow<Cardinality> + Borrow<BlsScalar>
+    Default
+    + Canon
+    + Annotation<L>
+    + Borrow<Cardinality>
+    + Borrow<BlsScalar>
+    + Combine<NStack<L, Self>, Self>
 where
-    L: PoseidonLeaf,
-{
-}
-
-impl<T, L> PoseidonTreeAnnotation<L> for T
-where
-    T: Default
-        + Canon
-        + Annotation<L>
-        + Borrow<Cardinality>
-        + Borrow<BlsScalar>,
     L: PoseidonLeaf,
 {
 }

--- a/src/tree/branch.rs
+++ b/src/tree/branch.rs
@@ -13,7 +13,6 @@ use core::ops::Deref;
 use dusk_bls12_381::BlsScalar;
 use dusk_hades::{ScalarStrategy, Strategy};
 use microkelvin::Branch;
-use microkelvin::Combine;
 use nstack::NStack;
 
 /// Represents a level of a branch on a given depth
@@ -104,7 +103,6 @@ impl<L, A, const DEPTH: usize> From<&Branch<'_, NStack<L, A>, A>>
 where
     L: PoseidonLeaf,
     A: PoseidonTreeAnnotation<L>,
-    A: Combine<NStack<L, A>, A>,
 {
     fn from(b: &Branch<'_, NStack<L, A>, A>) -> Self {
         let mut branch = PoseidonBranch::default();

--- a/src/tree/tree.rs
+++ b/src/tree/tree.rs
@@ -9,7 +9,7 @@ use crate::Error;
 use canonical::CanonError;
 use canonical_derive::Canon;
 use dusk_bls12_381::BlsScalar;
-use microkelvin::{Annotation, Branch, Cardinality, Combine, Nth, Walker};
+use microkelvin::{Branch, Cardinality, Combine, Nth, Walker};
 use nstack::NStack;
 
 /// Represents a Merkle Tree with a given depth that will be calculated using
@@ -19,7 +19,6 @@ pub struct PoseidonTree<L, A, const DEPTH: usize>
 where
     L: PoseidonLeaf,
     A: PoseidonTreeAnnotation<L>,
-    A: Annotation<L>,
 {
     inner: NStack<L, A>,
 }
@@ -28,7 +27,6 @@ impl<L, A, const DEPTH: usize> AsRef<NStack<L, A>> for PoseidonTree<L, A, DEPTH>
 where
     L: PoseidonLeaf,
     A: PoseidonTreeAnnotation<L>,
-    A: Annotation<L> + Combine<NStack<L, A>, A>,
 {
     fn as_ref(&self) -> &NStack<L, A> {
         &self.inner
@@ -39,7 +37,6 @@ impl<L, A, const DEPTH: usize> AsMut<NStack<L, A>> for PoseidonTree<L, A, DEPTH>
 where
     L: PoseidonLeaf,
     A: PoseidonTreeAnnotation<L>,
-    A: Annotation<L> + Combine<NStack<L, A>, A>,
 {
     fn as_mut(&mut self) -> &mut NStack<L, A> {
         &mut self.inner
@@ -50,7 +47,6 @@ impl<L, A, const DEPTH: usize> Default for PoseidonTree<L, A, DEPTH>
 where
     L: PoseidonLeaf,
     A: PoseidonTreeAnnotation<L>,
-    A: Annotation<L> + Combine<NStack<L, A>, A>,
 {
     fn default() -> Self {
         PoseidonTree::new()
@@ -61,7 +57,6 @@ impl<L, A, const DEPTH: usize> PoseidonTree<L, A, DEPTH>
 where
     L: PoseidonLeaf,
     A: PoseidonTreeAnnotation<L>,
-    A: Annotation<L> + Combine<NStack<L, A>, A>,
 {
     /// Creates a new poseidon tree
     pub fn new() -> Self {

--- a/tests/block_height.rs
+++ b/tests/block_height.rs
@@ -5,16 +5,13 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 #![cfg(feature = "canon")]
-#![cfg(test)]
 use canonical_derive::Canon;
 use core::borrow::Borrow;
 use dusk_bls12_381::BlsScalar;
-use dusk_poseidon::tree::{
-    PoseidonAnnotation, PoseidonLeaf, PoseidonTree, PoseidonTreeAnnotation,
-};
+use dusk_poseidon::tree::{PoseidonLeaf, PoseidonMaxAnnotation, PoseidonTree};
+use dusk_poseidon::Error;
 use microkelvin::{
-    Annotation, Cardinality, Child, Combine, Compound, Keyed, MaxKey, Step,
-    Walk, Walker,
+    Child, Combine, Compound, Keyed, MaxKey, Step, Walk, Walker,
 };
 
 #[derive(Debug, Default, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Canon)]
@@ -63,61 +60,6 @@ impl Borrow<u64> for TestLeaf {
 #[derive(Copy, Clone, Default, Debug, Canon, Ord, PartialOrd, Eq, PartialEq)]
 pub struct BlockHeight(pub(crate) u64);
 
-#[derive(Clone, Debug, Default, Canon)]
-pub struct TestAnnotation {
-    ann: PoseidonAnnotation,
-    block_height: MaxKey<BlockHeight>,
-}
-
-impl Borrow<MaxKey<BlockHeight>> for TestAnnotation {
-    fn borrow(&self) -> &MaxKey<BlockHeight> {
-        &self.block_height
-    }
-}
-
-impl Borrow<Cardinality> for TestAnnotation {
-    fn borrow(&self) -> &Cardinality {
-        self.ann.borrow()
-    }
-}
-
-impl Borrow<BlsScalar> for TestAnnotation {
-    fn borrow(&self) -> &BlsScalar {
-        self.ann.borrow()
-    }
-}
-
-impl<L> Annotation<L> for TestAnnotation
-where
-    L: PoseidonLeaf,
-    L: Borrow<u64>,
-    L: Keyed<BlockHeight>,
-{
-    fn from_leaf(leaf: &L) -> Self {
-        let ann = PoseidonAnnotation::from_leaf(leaf);
-        let block_height = MaxKey::from_leaf(leaf);
-
-        Self { ann, block_height }
-    }
-}
-
-impl<C, A> Combine<C, A> for TestAnnotation
-where
-    C: Compound<A>,
-    C::Leaf: PoseidonLeaf + Keyed<BlockHeight> + Borrow<u64>,
-    A: Annotation<C::Leaf>
-        + PoseidonTreeAnnotation<C::Leaf>
-        + Borrow<Cardinality>
-        + Borrow<MaxKey<BlockHeight>>,
-{
-    fn combine(node: &C) -> Self {
-        TestAnnotation {
-            ann: PoseidonAnnotation::combine(node),
-            block_height: MaxKey::combine(node),
-        }
-    }
-}
-
 // Walker method to find the elements that are avobe a certain a block height.
 pub struct BlockHeightFilter(u64);
 
@@ -157,57 +99,53 @@ where
     }
 }
 
-mod tests {
-    use super::*;
-    use dusk_poseidon::Error;
+#[test]
+fn custom_walker_iter() -> Result<(), Error> {
+    let mut tree =
+        PoseidonTree::<TestLeaf, PoseidonMaxAnnotation<BlockHeight>, 17>::new();
 
-    #[test]
-    fn custom_walker_iter() -> Result<(), Error> {
-        let mut tree = PoseidonTree::<TestLeaf, TestAnnotation, 17>::new();
+    // Fill the tree with different leafs with different block heights.
+    for i in 0..18 {
+        let leaf = TestLeaf::new(i);
+        let pos = tree.push(leaf)?;
+        assert_eq!(pos, i);
+        let key: BlockHeight = *leaf.key();
+        assert_eq!(key, BlockHeight(i as u64));
+    }
 
-        // Fill the tree with different leafs with different block heights.
-        for i in 0..18 {
-            let leaf = TestLeaf::new(i);
-            let pos = tree.push(leaf)?;
-            assert_eq!(pos, i);
-            let key: BlockHeight = *leaf.key();
-            assert_eq!(key, BlockHeight(i as u64));
-        }
+    let mut leaf_count = 0;
+    // For a block_height of 0, the custom walker should iterate over all the leaves.
+    tree.annotated_iter_walk(BlockHeightFilter(0))?
+        .into_iter()
+        .enumerate()
+        .for_each(|(idx, l)| {
+            if l.is_ok() {
+                leaf_count += 1
+            }
+            // Check that the heights are the expected ones
+            let leaf_height: BlockHeight = *l.unwrap().key();
+            assert_eq!(leaf_height, BlockHeight(idx as u64));
+        });
+    assert_eq!(leaf_count, 18);
 
-        let mut leaf_count = 0;
-        // For a block_height of 0, the custom walker should iterate over all the leaves.
-        tree.annotated_iter_walk(BlockHeightFilter(0))?
-            .into_iter()
-            .enumerate()
-            .for_each(|(idx, l)| {
-                if l.is_ok() {
-                    leaf_count += 1
-                }
+    // For a block_height of 20, we should fail to get an iterator over the tree as no leaf
+    // satisfies the criteria.
+    assert!(tree.annotated_iter_walk(BlockHeightFilter(20)).is_err());
+
+    leaf_count = 0;
+    // For a block_height of 15, the custom walker should iterate over the last two subtrees which means from
+    // leaves [12, 13, 14, 15] & [16, 17, _, _].
+    tree.annotated_iter_walk(BlockHeightFilter(15))?
+        .into_iter()
+        .enumerate()
+        .for_each(|(idx, l)| {
+            if l.is_ok() {
+                leaf_count += 1;
                 // Check that the heights are the expected ones
                 let leaf_height: BlockHeight = *l.unwrap().key();
-                assert_eq!(leaf_height, BlockHeight(idx as u64));
-            });
-        assert_eq!(leaf_count, 18);
-
-        // For a block_height of 20, we should fail to get an iterator over the tree as no leaf
-        // satisfies the criteria.
-        assert!(tree.annotated_iter_walk(BlockHeightFilter(20)).is_err());
-
-        leaf_count = 0;
-        // For a block_height of 15, the custom walker should iterate over the last two subtrees which means from
-        // leaves [12, 13, 14, 15] & [16, 17, _, _].
-        tree.annotated_iter_walk(BlockHeightFilter(15))?
-            .into_iter()
-            .enumerate()
-            .for_each(|(idx, l)| {
-                if l.is_ok() {
-                    leaf_count += 1;
-                    // Check that the heights are the expected ones
-                    let leaf_height: BlockHeight = *l.unwrap().key();
-                    assert_eq!(leaf_height, BlockHeight(idx as u64 + 12));
-                }
-            });
-        assert_eq!(leaf_count, 6);
-        Ok(())
-    }
+                assert_eq!(leaf_height, BlockHeight(idx as u64 + 12));
+            }
+        });
+    assert_eq!(leaf_count, 6);
+    Ok(())
 }

--- a/tests/max_annotation.rs
+++ b/tests/max_annotation.rs
@@ -98,7 +98,7 @@ fn tree_append_fetch() {
 fn tree_max_walk() {
     const MAX: u64 = 1025;
 
-    let mut tree: PoseidonTree<MockLeaf, PoseidonMaxAnnotation, 17> =
+    let mut tree: PoseidonTree<MockLeaf, PoseidonMaxAnnotation<u64>, 17> =
         PoseidonTree::new();
     for i in 0..MAX {
         let s = MockLeaf::from(i as u64);
@@ -124,7 +124,7 @@ fn tree_max_walk() {
 fn tree_max_walk_non_continuous() {
     const MAX: u64 = 1025u64;
 
-    let mut tree: PoseidonTree<MockLeaf, PoseidonMaxAnnotation, 17> =
+    let mut tree: PoseidonTree<MockLeaf, PoseidonMaxAnnotation<u64>, 17> =
         PoseidonTree::new();
 
     for i in 0..MAX {


### PR DESCRIPTION
The poseidon tree annotations are meant to guard the user from all
Microkelvin/NStack dependencies.

The last update introduced a `Annotation<L> + Combine<NStack<L, A, A>`
that is not required and violates this principle.

Resolves #146