### PR TITLE
Change merkle opening to constrain leaf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Change merkle opening to constrain leaf [#162]
+
 ## [0.22.0] - 2021-07-27
 
 ### Changed
@@ -278,6 +280,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Poseidon252 Sponge-hash impl with BulletProofs.
 - Variants of sponge for `Scalar` & `Gadget(Variable/LC)`.
 
+[#162]: https://github.com/dusk-network/poseidon252/issues/162
 [#158]: https://github.com/dusk-network/poseidon252/issues/158
 [#153]: https://github.com/dusk-network/poseidon252/issues/153
 [#151]: https://github.com/dusk-network/poseidon252/issues/151

--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ struct DataLeaf {
     pos: u64,
 }
 
+impl DataLeaf {
+    pub const fn data(&self) -> &BlsScalar {
+        &self.data
+    }
+}
+
 // Example helper
 impl From<u64> for DataLeaf {
     fn from(n: u64) -> DataLeaf {
@@ -134,10 +140,13 @@ fn main() -> Result<(), Error> {
         |composer: &mut StandardComposer,
          tree: &PoseidonTree<DataLeaf, PoseidonAnnotation, DEPTH>,
          n: usize| {
+            let leaf = tree.get(n as u64).unwrap().unwrap();
+            let leaf = composer.add_input(*leaf.data());
+
             let branch = tree.branch(n as u64).unwrap().unwrap();
             let root = tree.root().unwrap();
 
-            let root_p = merkle_opening::<DEPTH>(composer, &branch);
+            let root_p = merkle_opening::<DEPTH>(composer, &branch, leaf);
             composer.constrain_to_constant(root_p, BlsScalar::zero(), Some(-root));
         };
 

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -27,6 +27,12 @@
 //!     pos: u64,
 //! }
 //!
+//! impl DataLeaf {
+//!     pub const fn data(&self) -> &BlsScalar {
+//!         &self.data
+//!     }
+//! }
+//!
 //! // Example helper
 //! impl From<u64> for DataLeaf {
 //!     fn from(n: u64) -> DataLeaf {
@@ -73,10 +79,13 @@
 //!     let gadget_tester = |composer: &mut StandardComposer,
 //!                          tree: &PoseidonTree<DataLeaf, PoseidonAnnotation, DEPTH>,
 //!                          n: usize| {
+//!         let leaf = tree.get(n as u64).unwrap().unwrap();
+//!         let leaf = composer.add_input(*leaf.data());
+//!
 //!         let branch = tree.branch(n as u64).unwrap().unwrap();
 //!         let root = tree.root().unwrap();
 //!
-//!         let root_p = merkle_opening::<DEPTH>(composer, &branch);
+//!         let root_p = merkle_opening::<DEPTH>(composer, &branch, leaf);
 //!         composer.constrain_to_constant(root_p, BlsScalar::zero(), Some(-root));
 //!     };
 //!

--- a/tests/zk.rs
+++ b/tests/zk.rs
@@ -54,8 +54,15 @@ impl Circuit for MerkleOpeningCircuit {
         &mut self,
         composer: &mut StandardComposer,
     ) -> Result<(), PlonkError> {
+        use std::ops::Deref;
+
+        let leaf: BlsScalar = *self.branch.deref();
         let root = self.branch.root();
-        let root_p = tree::merkle_opening::<DEPTH>(composer, &self.branch);
+
+        let leaf = composer.add_input(leaf);
+
+        let root_p =
+            tree::merkle_opening::<DEPTH>(composer, &self.branch, leaf);
 
         composer.constrain_to_constant(root_p, BlsScalar::zero(), Some(-root));
 


### PR DESCRIPTION
If the merkle opening doesn't constrain the leaf, the consumer of the
library need to be aware of the poseidon internals, select the merkle
bit and constrain it manually.

By constraining it in the opening gadget, we consume only a single gate
and protect the user from poseidon internals.

Resolves #162