### PR TITLE
Bump to version `0.27.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.0] - 2022-10-19
+
 ### Added
 
 - Add support for `rkyv-impl` under `no_std`
@@ -366,7 +368,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#112]: https://github.com/dusk-network/poseidon252/issues/112
 
 <!-- VERSIONS -->
-[unreleased]: https://github.com/dusk-network/poseidon252/compare/v0.26.0...HEAD
+[Unreleased]: https://github.com/dusk-network/poseidon252/compare/v0.27.0...HEAD
+[0.27.0]: https://github.com/dusk-network/poseidon252/compare/v0.26.0...v0.27.0
 [0.26.0]: https://github.com/dusk-network/poseidon252/compare/v0.22.0...v0.26.0
 [0.22.0]: https://github.com/dusk-network/poseidon252/compare/v0.21.0...v0.22.0
 [0.21.0]: https://github.com/dusk-network/poseidon252/compare/v0.20.0...v0.21.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-poseidon"
-version = "0.26.0"
+version = "0.27.0"
 description = "Implementation of Poseidon hash algorithm over the Bls12-381 Scalar field."
 categories = ["algorithms", "cryptography", "no-std", "wasm"]
 keywords = ["cryptography", "zero-knowledge", "crypto"]


### PR DESCRIPTION
### Added

- Add support for `rkyv-impl` under `no_std`
- Add `ranno` version `0.1` to dependencies [#180]

### Changed

- Change `PoseidonBranch` to have two fields - `root` and `path`. The path is
  now a fixed length array. [#189]
- Change `PoseidonTree` to build only with the `alloc` feature [#180]
- Change `PoseidonTree` to take a generic `Keyed` over the leaf type
  instead of a `PoseidonAnnotation` [#180]
- Make `PoseidonTree::new` const [#180]
- Update `microkelvin` from `0.15` to `0.17` [#180]
- Update `nstack` from `0.14.0-rc` to `0.16` [#180]

### Removed

- Remove `PoseidonBranch` `Default` implementation [#189]
- Remove `std` feature [#180]
- Remove `canon` and `persistence` features [#180]
- Remove `Error` struct [#180]
- Remove `canonical` and `canonical-derive` from dependencies [#180]
- Remove `PoseidonMaxAnnotation` [#180]

### Fixed

- Fix merkle opening circuit [#181]
- Fix CHANGELOG version links [#191]