### PR TITLE
Upgrade to `plonk` version `0.13`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update `dusk-plonk` from `0.12` to `0.13`
+- Update `dusk-hades` from `0.19` to `0.20`
+
 ## [0.27.0] - 2022-10-19
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ dusk-bls12_381 = { version = "0.11", default-features = false }
 dusk-jubjub = { version = "0.12", default-features = false }
 dusk-bytes = "0.1"
 dusk-hades = "0.20"
-microkelvin = { version = "0.17.0-rc", optional = true }
-nstack = { version = "0.16.0-rc", optional = true }
+microkelvin = { version = "0.17", optional = true }
+nstack = { version = "0.16", optional = true }
 ranno = { version = "0.1", optional = true }
 dusk-plonk = { version = "0.13", default-features = false, features = ["alloc"] }
 rkyv = { version = "0.7", optional = true, default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ authors = [
     "CPerezz <carlos@dusk.network>",
     "Kristoffer Ström <kristoffer@dusk.network>",
     "Eduardo Leegwater Simões <eduardo@dusk.network>",
-	"Moana Marcello <moana@dusk.network>",
+    "Moana Marcello <moana@dusk.network>",
 ]
 edition = "2021"
 license = "MPL-2.0"
@@ -21,16 +21,17 @@ license = "MPL-2.0"
 dusk-bls12_381 = { version = "0.11", default-features = false }
 dusk-jubjub = { version = "0.12", default-features = false }
 dusk-bytes = "0.1"
-dusk-hades = "0.19"
+dusk-hades = "0.20"
 microkelvin = { version = "0.17.0-rc", optional = true }
 nstack = { version = "0.16.0-rc", optional = true }
 ranno = { version = "0.1", optional = true }
-dusk-plonk = { version = "0.12", default-features = false, features = ["alloc"] }
+dusk-plonk = { version = "0.13", default-features = false, features = ["alloc"] }
 rkyv = { version = "0.7", optional = true, default-features = false }
 bytecheck = { version = "0.6", optional = true, default-features = false }
 
 [dev-dependencies]
-rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
+rand = { version = "0.8", default-features = false, features = ["getrandom", "std_rng"] }
+rkyv = { version = "0.7", default-features = false, features = ["size_32"] }
 
 [features]
 default = [

--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -25,7 +25,7 @@
 //! use dusk_bls12_381::BlsScalar;
 //! use dusk_jubjub::{dhke, JubJubExtended, JubJubScalar, GENERATOR};
 //! use dusk_poseidon::cipher::PoseidonCipher;
-//! use rand_core::OsRng;
+//! use rand::rngs::OsRng;
 //!
 //! fn sender(
 //!     sender_secret: &JubJubScalar,

--- a/src/perm_uses.rs
+++ b/src/perm_uses.rs
@@ -30,7 +30,7 @@ pub fn two_outputs(message: BlsScalar) -> [BlsScalar; 2] {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rand_core::OsRng;
+    use rand::rngs::OsRng;
 
     #[test]
     fn hash_two_outputs() {

--- a/src/sponge/gadget.rs
+++ b/src/sponge/gadget.rs
@@ -21,9 +21,11 @@ use dusk_plonk::prelude::*;
 /// The returned value is the hashed witness data computed as a variable.
 ///
 /// [`hash`]: crate::sponge::hash
-pub fn gadget(composer: &mut TurboComposer, messages: &[Witness]) -> Witness {
-    let zero = TurboComposer::constant_zero();
-    let mut state = [zero; WIDTH];
+pub fn gadget<C>(composer: &mut C, messages: &[Witness]) -> Witness
+where
+    C: Composer,
+{
+    let mut state = [C::ZERO; WIDTH];
 
     let l = messages.len();
     let m = l / (WIDTH - 1);

--- a/src/sponge/truncated.rs
+++ b/src/sponge/truncated.rs
@@ -57,10 +57,12 @@ pub fn hash(messages: &[BlsScalar]) -> JubJubScalar {
 ///
 /// [`hash`]: crate::sponge::hash
 #[cfg(feature = "alloc")]
-pub fn gadget(composer: &mut TurboComposer, message: &[Witness]) -> Witness {
-    let zero = TurboComposer::constant_zero();
+pub fn gadget<C>(composer: &mut C, message: &[Witness]) -> Witness
+where
+    C: Composer,
+{
     let h = sponge::gadget(composer, message);
 
     // Truncate to 250 bits
-    composer.component_xor(h, zero, 250)
+    composer.append_logic_xor(h, C::ZERO, 250)
 }

--- a/src/tree/branch.rs
+++ b/src/tree/branch.rs
@@ -90,6 +90,15 @@ impl<const DEPTH: usize> PoseidonBranch<DEPTH> {
     }
 }
 
+impl<const DEPTH: usize> Default for PoseidonBranch<DEPTH> {
+    fn default() -> Self {
+        Self {
+            path: [PoseidonLevel::default(); DEPTH],
+            root: BlsScalar::default(),
+        }
+    }
+}
+
 impl<const DEPTH: usize> Deref for PoseidonBranch<DEPTH> {
     type Target = BlsScalar;
 

--- a/tests/max_annotation.rs
+++ b/tests/max_annotation.rs
@@ -11,7 +11,7 @@ use dusk_bls12_381::BlsScalar;
 use dusk_hades::{ScalarStrategy, Strategy};
 use dusk_poseidon::tree::{PoseidonLeaf, PoseidonTree};
 use nstack::annotation::Keyed;
-use rand_core::{CryptoRng, RngCore};
+use rand::{CryptoRng, RngCore};
 
 #[derive(Debug, Default, Clone, Copy, PartialOrd, Ord, PartialEq, Eq)]
 pub struct MockLeaf {


### PR DESCRIPTION
This PR also removes the non-necessary `rc` status of the `microkelvin` and `nstack` dependencies.