### PR TITLE
Release `0.28.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.1] - 2023-01-18
+
 ### Added
 
 - Implement `dusk_bytes::Serializable` for `PoseidonBranch` and `PoseidonLevel` [#203]
@@ -16,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Derive `Copy` for `PoseidonBranch` [#200]
 
-## [0.28.0]
+## [0.28.0] - 2022-11-10
 
 ### Changed
 
@@ -387,7 +389,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#112]: https://github.com/dusk-network/poseidon252/issues/112
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/poseidon252/compare/v0.28.0...HEAD
+[Unreleased]: https://github.com/dusk-network/poseidon252/compare/v0.28.1...HEAD
+[0.28.1]: https://github.com/dusk-network/poseidon252/compare/v0.28.0...v0.28.1
 [0.28.0]: https://github.com/dusk-network/poseidon252/compare/v0.27.0...v0.28.0
 [0.27.0]: https://github.com/dusk-network/poseidon252/compare/v0.26.0...v0.27.0
 [0.26.0]: https://github.com/dusk-network/poseidon252/compare/v0.22.0...v0.26.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-poseidon"
-version = "0.28.0"
+version = "0.28.1"
 description = "Implementation of Poseidon hash algorithm over the Bls12-381 Scalar field."
 categories = ["algorithms", "cryptography", "no-std", "wasm"]
 keywords = ["cryptography", "zero-knowledge", "crypto"]


### PR DESCRIPTION
## [0.28.1] - 2023-01-18

### Added

- Implement `dusk_bytes::Serializable` for `PoseidonBranch` and `PoseidonLevel` [#203]
- Add benchmarks for merkle opening proof [#197]

### Changed

- Derive `Copy` for `PoseidonBranch` [#200]

[0.28.1]: https://github.com/dusk-network/poseidon252/compare/v0.28.0...v0.28.1