### PR TITLE
Release v0.28.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.2] - 2023-04-06
+
 ### Added
 
 - Add benchmark for running sponge gadged on 5 BlsScalar (one permutation) [#206]
@@ -396,7 +398,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#112]: https://github.com/dusk-network/poseidon252/issues/112
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/poseidon252/compare/v0.28.1...HEAD
+[Unreleased]: https://github.com/dusk-network/poseidon252/compare/v0.28.2...HEAD
+[0.28.2]: https://github.com/dusk-network/poseidon252/compare/v0.28.1...v0.28.2
 [0.28.1]: https://github.com/dusk-network/poseidon252/compare/v0.28.0...v0.28.1
 [0.28.0]: https://github.com/dusk-network/poseidon252/compare/v0.27.0...v0.28.0
 [0.27.0]: https://github.com/dusk-network/poseidon252/compare/v0.26.0...v0.27.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-poseidon"
-version = "0.28.1"
+version = "0.28.2"
 description = "Implementation of Poseidon hash algorithm over the Bls12-381 Scalar field."
 categories = ["algorithms", "cryptography", "no-std", "wasm"]
 keywords = ["cryptography", "zero-knowledge", "crypto"]


### PR DESCRIPTION
## [0.28.2](https://github.com/dusk-network/poseidon252/compare/v0.28.1...v0.28.2) - 2023-04-06

### Added

- Add benchmark for running sponge gadged on 5 BlsScalar (one permutation) [#206]
- Add benchmarks for cypher in native and zk [#197]

