### PR TITLE
Bump to `v0.30.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.0] - 2023-06-28
+
 ### Changed
 
 - Update `dusk-plonk` from `0.13` to `0.14`
@@ -415,7 +417,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#112]: https://github.com/dusk-network/poseidon252/issues/112
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/poseidon252/compare/v0.29.0...HEAD
+[Unreleased]: https://github.com/dusk-network/poseidon252/compare/v0.30.0...HEAD
+[0.30.0]: https://github.com/dusk-network/poseidon252/compare/v0.29.2...v0.30.0
 [0.29.0]: https://github.com/dusk-network/poseidon252/compare/v0.28.2...v0.29.0
 [0.28.2]: https://github.com/dusk-network/poseidon252/compare/v0.28.1...v0.28.2
 [0.28.1]: https://github.com/dusk-network/poseidon252/compare/v0.28.0...v0.28.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-poseidon"
-version = "0.29.1-rc.0"
+version = "0.30.0"
 description = "Implementation of Poseidon hash algorithm over the Bls12-381 Scalar field."
 categories = ["algorithms", "cryptography", "no-std", "wasm"]
 keywords = ["cryptography", "zero-knowledge", "crypto"]


### PR DESCRIPTION
## [0.30.0] - 2023-06-28

### Changed

- Update `dusk-plonk` from `0.13` to `0.14`
- Update `dusk-hades` from `0.20` to `0.21`

[0.30.0]: https://github.com/dusk-network/poseidon252/compare/v0.29.2...v0.30.0
