### PR TITLE
Bump to `0.30.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.1] - 2023-06-28
+
+### Fixed
+
+- Fix missing `rkyv` feature
+
 ## [0.30.0] - 2023-06-28
 
 ### Changed
@@ -417,7 +423,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#112]: https://github.com/dusk-network/poseidon252/issues/112
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/poseidon252/compare/v0.30.0...HEAD
+[Unreleased]: https://github.com/dusk-network/poseidon252/compare/v0.30.1...HEAD
+[0.30.1]: https://github.com/dusk-network/poseidon252/compare/v0.30.0...v0.30.1
 [0.30.0]: https://github.com/dusk-network/poseidon252/compare/v0.29.2...v0.30.0
 [0.29.0]: https://github.com/dusk-network/poseidon252/compare/v0.28.2...v0.29.0
 [0.28.2]: https://github.com/dusk-network/poseidon252/compare/v0.28.1...v0.28.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-poseidon"
-version = "0.30.0"
+version = "0.30.1"
 description = "Implementation of Poseidon hash algorithm over the Bls12-381 Scalar field."
 categories = ["algorithms", "cryptography", "no-std", "wasm"]
 keywords = ["cryptography", "zero-knowledge", "crypto"]


### PR DESCRIPTION
## [0.30.1] - 2023-06-28

### Fixed

- Fix missing `rkyv` feature

[0.30.1]: https://github.com/dusk-network/poseidon252/compare/v0.30.0...v0.30.1
