### PR TITLE
Bump to v0.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.34.0] - 2024-01-24
+
 ### Changed
 
 - Restructure crate features [#184]
@@ -461,7 +463,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#112]: https://github.com/dusk-network/poseidon252/issues/112
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/poseidon252/compare/v0.33.0...HEAD
+[Unreleased]: https://github.com/dusk-network/poseidon252/compare/v0.34.0...HEAD
+[0.34.0]: https://github.com/dusk-network/poseidon252/compare/v0.33.0...v0.34.0
 [0.33.0]: https://github.com/dusk-network/poseidon252/compare/v0.32.0...v0.33.0
 [0.32.0]: https://github.com/dusk-network/poseidon252/compare/v0.31.0...v0.32.0
 [0.31.0]: https://github.com/dusk-network/poseidon252/compare/v0.30.1...v0.31.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-poseidon"
-version = "0.33.0"
+version = "0.34.0"
 description = "Implementation of Poseidon hash algorithm over the Bls12-381 Scalar field."
 categories = ["algorithms", "cryptography", "no-std", "wasm"]
 keywords = ["cryptography", "zero-knowledge", "crypto"]


### PR DESCRIPTION
## [0.34.0] - 2024-01-24

### Changed

- Restructure crate features [#184]

### Removed

- Remove `default` and `alloc` features [#184]

### Added

- Add `zk` and `cipher` features [#184]



[0.34.0]: https://github.com/dusk-network/poseidon252/compare/v0.33.0...v0.34.0
