### PR TITLE
Bump to v0.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.35.0] - 2024-02-28
+
 ### Changed
 
 - Rename trait `hades::Strategy` to `hades::Permutation` [#243]
@@ -486,7 +488,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#112]: https://github.com/dusk-network/poseidon252/issues/112
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/poseidon252/compare/v0.34.0...HEAD
+[Unreleased]: https://github.com/dusk-network/poseidon252/compare/v0.35.0...HEAD
+[0.35.0]: https://github.com/dusk-network/poseidon252/compare/v0.34.0...v0.35.0
 [0.34.0]: https://github.com/dusk-network/poseidon252/compare/v0.33.0...v0.34.0
 [0.33.0]: https://github.com/dusk-network/poseidon252/compare/v0.32.0...v0.33.0
 [0.32.0]: https://github.com/dusk-network/poseidon252/compare/v0.31.0...v0.32.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-poseidon"
-version = "0.34.0"
+version = "0.35.0"
 description = "Implementation of Poseidon hash algorithm over the Bls12-381 Scalar field."
 categories = ["algorithms", "cryptography", "no-std", "wasm"]
 keywords = ["cryptography", "zero-knowledge", "crypto"]


### PR DESCRIPTION
## [0.35.0] - 2024-02-28

### Changed

- Rename trait `hades::Strategy` to `hades::Permutation` [#243]
- Rename struct `hades::ScalarStrategy` to `hades::ScalarPermutation` [#243]
- Rename struct `hades::GadgetStrategy` to `hades::GadgetPermutaiton` [#243]
- Reduce the number of `ROUND_CONSTANTS` from 960 to 335 [#246]
- Remove the constants iterator in favor of indexing the constants array directly [#246]
- Change `ROUND_CONSTANTS` into a two-dimensional array [#246]
- Rename `TOTAL_FULL_ROUNDS` to `FULL_ROUNDS` [#246]

### Removed

- Remove `hades::Strategy`, `hades::ScalarStrategy` and `hades::GadgetStrategy` from public API [#243]
- Remove `dusk-hades` dependency [#240]

### Added

- Add the code for the hades permutation to crate [#240]
- Add internal `permute` and `permute_gadget` functions to `hades` module [#243]




[0.35.0]: https://github.com/dusk-network/poseidon252/compare/v0.34.0...v0.35.0
