### PR TITLE
Update criterion dependency to 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ dusk-plonk = { version = "0.19.2-rc.0", default-features = false, features = ["a
 dusk-safe = "0.2.0-rc.0"
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = "0.5"
 rand = { version = "0.8", default-features = false, features = ["getrandom", "std_rng"] }
 ff = { version = "0.13", default-features = false }
 once_cell = "1"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-05-22"
+channel = "nightly-2023-11-10"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
This PR also updates the toolchain to nightly-2023-11-10.

Resolves #255 