### PR TITLE
Bump to 0.37.0-rc.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-poseidon"
-version = "0.36.0"
+version = "0.37.0-rc.0"
 description = "Implementation of Poseidon hash algorithm over the Bls12-381 Scalar field."
 categories = ["algorithms", "cryptography", "no-std", "wasm"]
 keywords = ["cryptography", "zero-knowledge", "crypto"]


### PR DESCRIPTION
### Added

- Add variable length encryption and decryption [#236]
- Add variable length encryption and decryption gadgets [#236]
- Add `encryption` feature [#236]

### Removed

- Remove `PoseidonCipher` struct as it is replaced by encryption functions [#236]
- Remove `cipher` feature [#236]
- Remove `rkyv` dependency and all related features [#236]
- Remove `bytecheck` dependency [#236]
- Remove `dusk-bytes` dependency [#236]

### Changed

- Append the tag as a constant when initializing the gadget state [#236]
