### PR TITLE
Bump to v0.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.37.0] - 2024-03-27
+
 ### Added
 
 - Add variable length encryption and decryption [#236]
@@ -532,7 +534,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#112]: https://github.com/dusk-network/poseidon252/issues/112
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/poseidon252/compare/v0.36.0...HEAD
+[Unreleased]: https://github.com/dusk-network/poseidon252/compare/v0.37.0...HEAD
+[0.37.0]: https://github.com/dusk-network/poseidon252/compare/v0.36.0...v0.37.0
 [0.36.0]: https://github.com/dusk-network/poseidon252/compare/v0.35.0...v0.36.0
 [0.35.0]: https://github.com/dusk-network/poseidon252/compare/v0.34.0...v0.35.0
 [0.34.0]: https://github.com/dusk-network/poseidon252/compare/v0.33.0...v0.34.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-poseidon"
-version = "0.37.0-rc.0"
+version = "0.37.0"
 description = "Implementation of Poseidon hash algorithm over the Bls12-381 Scalar field."
 categories = ["algorithms", "cryptography", "no-std", "wasm"]
 keywords = ["cryptography", "zero-knowledge", "crypto"]
@@ -12,8 +12,8 @@ license = "MPL-2.0"
 [dependencies]
 dusk-bls12_381 = { version = "0.13", default-features = false, features = ["zeroize"] }
 dusk-jubjub = { version = "0.14", default-features = false }
-dusk-plonk = { version = "0.19.2-rc.0", default-features = false, features = ["alloc", "zeroize"], optional = true }
-dusk-safe = "0.2.0-rc.0"
+dusk-plonk = { version = "0.19", default-features = false, features = ["alloc", "zeroize"], optional = true }
+dusk-safe = "0.2"
 
 [dev-dependencies]
 criterion = "0.5"


### PR DESCRIPTION
## [0.37.0] - 2024-03-27

### Added

- Add variable length encryption and decryption [#236]
- Add variable length encryption and decryption gadgets [#236]
- Add `encryption` feature [#236]

### Removed

- Remove `PoseidonCipher` struct as it is replaced by encryption functions [#236]
- Remove `cipher` feature [#236]
- Remove `rkyv` dependency and all related features [#236]
- Remove `bytecheck` dependency [#236]
- Remove `dusk-bytes` dependency [#236]

### Changed

- Append the tag as a constant when initializing the gadget state [#236]


[0.37.0]: https://github.com/dusk-network/poseidon252/compare/v0.36.0...v0.37.0
