### PR TITLE
Bump to v0.38.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.38.0] - 2024-04-24
+
 ### Changed
 
 - Change `const PARTIAL_ROUNDS` to 60 (was 59) [#260]
@@ -542,7 +544,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#112]: https://github.com/dusk-network/poseidon252/issues/112
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/poseidon252/compare/v0.37.0...HEAD
+[Unreleased]: https://github.com/dusk-network/poseidon252/compare/v0.38.0...HEAD
+[0.38.0]: https://github.com/dusk-network/poseidon252/compare/v0.37.0...v0.38.0
 [0.37.0]: https://github.com/dusk-network/poseidon252/compare/v0.36.0...v0.37.0
 [0.36.0]: https://github.com/dusk-network/poseidon252/compare/v0.35.0...v0.36.0
 [0.35.0]: https://github.com/dusk-network/poseidon252/compare/v0.34.0...v0.35.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-poseidon"
-version = "0.37.0"
+version = "0.38.0"
 description = "Implementation of Poseidon hash algorithm over the Bls12-381 Scalar field."
 categories = ["algorithms", "cryptography", "no-std", "wasm"]
 keywords = ["cryptography", "zero-knowledge", "crypto"]


### PR DESCRIPTION
## [0.38.0] - 2024-04-24

### Changed

- Change `const PARTIAL_ROUNDS` to 60 (was 59) [#260]
- Increase the number of constants to 340 (was 335) [#260]
- Change `finalize` to return the hash directly [#259]


[0.38.0]: https://github.com/dusk-network/poseidon252/compare/v0.37.0...v0.38.0
