### PR TITLE
Bump version to `0.41.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.41.0] - 2025-02-06
+
 ### Changed
 
 - Update to `dusk-plonk` v0.21
@@ -563,7 +565,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#112]: https://github.com/dusk-network/poseidon252/issues/112
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/poseidon252/compare/v0.40.0...HEAD
+[Unreleased]: https://github.com/dusk-network/poseidon252/compare/v0.41.0...HEAD
+[0.41.0]: https://github.com/dusk-network/poseidon252/compare/v0.40.0...v0.41.0
 [0.40.0]: https://github.com/dusk-network/poseidon252/compare/v0.39.0...v0.40.0
 [0.39.0]: https://github.com/dusk-network/poseidon252/compare/v0.38.0...v0.39.0
 [0.38.0]: https://github.com/dusk-network/poseidon252/compare/v0.37.0...v0.38.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-poseidon"
-version = "0.40.0"
+version = "0.41.0"
 description = "Implementation of Poseidon hash algorithm over the Bls12-381 Scalar field."
 categories = ["algorithms", "cryptography", "no-std", "wasm"]
 keywords = ["cryptography", "zero-knowledge", "crypto"]


### PR DESCRIPTION
## [0.41.0](https://github.com/dusk-network/poseidon252/compare/v0.40.0...v0.41.0) - 2025-02-06

### Changed

- Update to `dusk-plonk` v0.21
- Update to `dusk-safe` v0.3
- Update to `dusk-jubjub` v0.15
- Update to `dusk-bls12_381` v0.14