### PR TITLE
AI-friendliness pass

### DIFF
--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -18,22 +18,29 @@ jobs:
     name: Dusk Analyzer
     uses: dusk-network/.github/.github/workflows/dusk-analysis.yml@main
 
-  build_benches:
-    name: Build Benchmarks
-    runs-on: ubuntu-latest
+  test:
+    name: Test
+    runs-on: core
     steps:
       - uses: actions/checkout@v4
+      - uses: dsherret/rust-toolchain-file@v1
+      - uses: Swatinem/rust-cache@v2
+      - run: make test
+
+  no-std:
+    name: Build no_std
+    runs-on: core
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dsherret/rust-toolchain-file@v1
+      - uses: Swatinem/rust-cache@v2
+      - run: make no-std
+
+  build_benches:
+    name: Build Benchmarks
+    runs-on: core
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dsherret/rust-toolchain-file@v1
       - uses: Swatinem/rust-cache@v2
       - run: cargo bench --all-features --no-run
-
-  check_encryption:
-    name: Check encryption compiles without zk
-    uses: dusk-network/.github/.github/workflows/run-tests.yml@main
-    with:
-      test_flags: --features=encryption --no-run
-
-  test_all:
-    name: Tests all
-    uses: dusk-network/.github/.github/workflows/run-tests.yml@main
-    with:
-      test_flags: --all-features

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,89 @@
+# AGENTS.md — dusk-poseidon
+
+## Care Level: Cryptographic — Elevated
+
+Core hash function used across the Dusk stack (nullifiers, Merkle trees,
+encryption). A bug here affects consensus and privacy. See the root
+`CLAUDE.md` at `~/dusk/CLAUDE.md` for cross-repo propagation rules.
+
+## Overview
+
+Poseidon hash over the BLS12-381 scalar field. Uses the Hades252
+permutation (8 full + 60 partial rounds, width 5) via the SAFE sponge
+framework. Single crate, `no_std` with `alloc`.
+
+## Commands
+
+Run `make help` for the full target list.
+
+## Architecture
+
+### Key Files
+
+| Path | Purpose |
+|------|---------|
+| `src/hash.rs` | `Hash` struct — sponge-based with domain separation (Merkle2/4, Encryption, Other) |
+| `src/hades.rs` | Hades252 permutation algorithm |
+| `src/hades/mds_matrix.rs` | MDS (Cauchy) matrix constants |
+| `src/hades/round_constants.rs` | 340 round constants |
+| `src/encryption.rs` | Encrypt/decrypt using Poseidon + JubJub DHKE + SAFE |
+| `src/hash/gadget.rs` | ZK circuit gadget for hashing (`zk` feature) |
+| `src/encryption/gadget.rs` | ZK gadgets for encryption/decryption (`zk` + `encryption` features) |
+
+### Features
+
+- `zk` — PLONK circuit gadgets (gates `dusk-plonk`)
+- `encryption` — encrypt/decrypt module (gates `dusk-safe/encryption`)
+
+## Elevated Care Zones
+
+The entire crate is a care zone — it is a consensus-critical hash
+function. Changes to the permutation constants, round structure, or
+sponge logic can silently break nullifier derivation, Merkle proofs,
+and on-chain encryption.
+
+- **Hades permutation** (`src/hades/`): round constants, MDS matrix,
+  and round structure must match the specification exactly.
+- **Domain separation** (`src/hash.rs`): changing domain tags breaks
+  compatibility with all downstream consumers.
+- **Encryption** (`src/encryption.rs`): used for on-chain note
+  encryption in Phoenix.
+
+## Conventions
+
+- `no_std` with `alloc` — do not add `std` dependencies
+- **Always use `--release` for tests** — the `zk` feature pulls in
+  `dusk-plonk`, which is extremely slow in debug mode
+- No `unwrap()`/`expect()` outside of tests — return errors instead
+- No `#[allow(...)]` lint suppression — fix the underlying issue
+- Run `make fmt` before committing (requires nightly toolchain)
+- Run `make clippy` to check for warnings
+
+## Change Propagation
+
+| Changed | Also verify |
+|---------|-------------|
+| `dusk-poseidon` | `merkle` (poseidon-merkle), `phoenix`, `rusk` |
+
+## Git Conventions
+
+- Default branch: `master`
+- License: MPL-2.0
+
+### Commit messages
+
+Format: `<Description>` — imperative mood, capitalize first word.
+
+Cross-cutting prefixes (`ci`, `docs`, `chore`) for non-code changes.
+
+## Changelog
+
+- Update `CHANGELOG.md` under `[Unreleased]` for any user-visible
+  change
+- Use the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+  format
+- Only link to GitHub issues — no other tracking identifiers
+- Follow standard markdown formatting: separate headings from
+  surrounding content with blank lines, leave a blank line before and
+  after lists, and never have two headings back-to-back without a blank
+  line between them

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+help: ## Display this help screen
+	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+test: ## Run tests (--all-features, release mode)
+	@cargo test --all-features --release
+	@cargo test --features=encryption --no-run
+
+clippy: ## Run clippy
+	@cargo clippy --all-features -- -D warnings
+
+fmt: ## Format code
+	@cargo +nightly fmt --all
+
+check: ## Type-check
+	@cargo check --all-features
+
+doc: ## Generate docs
+	@cargo doc --no-deps --all-features
+
+clean: ## Clean build artifacts
+	@cargo clean
+
+no-std: ## Verify no_std bare-metal build
+	@rustup target add thumbv6m-none-eabi 2>/dev/null || true
+	@cargo build --release --no-default-features --target thumbv6m-none-eabi
+
+.PHONY: help test clippy fmt check doc clean no-std

--- a/benches/decrypt.rs
+++ b/benches/decrypt.rs
@@ -7,8 +7,7 @@
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use dusk_bls12_381::BlsScalar;
 use dusk_jubjub::{GENERATOR_EXTENDED, JubJubAffine, JubJubScalar};
-use dusk_plonk::prelude::Error as PlonkError;
-use dusk_plonk::prelude::*;
+use dusk_plonk::prelude::{Error as PlonkError, *};
 use dusk_poseidon::{decrypt, decrypt_gadget, encrypt};
 use ff::Field;
 use once_cell::sync::Lazy;

--- a/benches/encrypt.rs
+++ b/benches/encrypt.rs
@@ -7,8 +7,7 @@
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use dusk_bls12_381::BlsScalar;
 use dusk_jubjub::{GENERATOR_EXTENDED, JubJubAffine, JubJubScalar};
-use dusk_plonk::prelude::Error as PlonkError;
-use dusk_plonk::prelude::*;
+use dusk_plonk::prelude::{Error as PlonkError, *};
 use dusk_poseidon::{encrypt, encrypt_gadget};
 use ff::Field;
 use once_cell::sync::Lazy;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,6 @@
 max_width = 80
+unstable_features = true
+group_imports = "StdExternalCrate"
+imports_granularity = "Module"
+use_field_init_shorthand = true
+wrap_comments = true

--- a/src/hades.rs
+++ b/src/hades.rs
@@ -56,8 +56,7 @@ const fn u64_from_buffer<const N: usize>(buf: &[u8; N], i: usize) -> u64 {
 #[cfg(test)]
 mod tests {
     extern crate std;
-    use std::format;
-    use std::vec;
+    use std::{format, vec};
 
     use dusk_bls12_381::BlsScalar;
     use dusk_bytes::ParseHexStr;

--- a/src/hades/permutation.rs
+++ b/src/hades/permutation.rs
@@ -32,8 +32,6 @@ pub(crate) mod scalar;
 /// This structure allows to minimize the number of non-linear ops while
 /// maintaining the security.
 pub(crate) trait Hades<T> {
-    const ROUNDS: usize = FULL_ROUNDS + PARTIAL_ROUNDS;
-
     /// Add round constants to the state.
     ///
     /// This constants addition, also known as `ARC`, is used to reach

--- a/src/hades/permutation/gadget.rs
+++ b/src/hades/permutation/gadget.rs
@@ -9,6 +9,7 @@ use dusk_plonk::prelude::*;
 use dusk_safe::Safe;
 
 use super::Hades;
+use crate::hades::round_constants::ROUNDS;
 use crate::hades::{MDS_MATRIX, ROUND_CONSTANTS, WIDTH};
 
 /// An implementation for the [`Hades`] permutation operating on [`Witness`]es.
@@ -100,7 +101,7 @@ impl<'a> Hades<Witness> for GadgetPermutation<'a> {
         // r[x] = q_l · w_l + q_r · w_r + q_4 · w_4 + c;
         for j in 0..WIDTH {
             // c is the next round's constant and hence zero for the last round.
-            let c = match round + 1 < Self::ROUNDS {
+            let c = match round + 1 < ROUNDS {
                 true => ROUND_CONSTANTS[round + 1][j],
                 false => BlsScalar::zero(),
             };

--- a/src/hades/permutation/gadget.rs
+++ b/src/hades/permutation/gadget.rs
@@ -8,9 +8,8 @@ use dusk_bls12_381::BlsScalar;
 use dusk_plonk::prelude::*;
 use dusk_safe::Safe;
 
-use crate::hades::{MDS_MATRIX, ROUND_CONSTANTS, WIDTH};
-
 use super::Hades;
+use crate::hades::{MDS_MATRIX, ROUND_CONSTANTS, WIDTH};
 
 /// An implementation for the [`Hades`] permutation operating on [`Witness`]es.
 /// Requires a reference to a plonk circuit [`Composer`].
@@ -153,14 +152,14 @@ impl dusk_safe::Encryption<Witness, WIDTH> for GadgetPermutation<'_> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
-    use crate::hades::ScalarPermutation;
-
     use core::result::Result;
+
     use ff::Field;
     use rand::SeedableRng;
     use rand::rngs::StdRng;
+
+    use super::*;
+    use crate::hades::ScalarPermutation;
 
     #[derive(Default)]
     struct TestCircuit {

--- a/src/hades/round_constants.rs
+++ b/src/hades/round_constants.rs
@@ -15,7 +15,7 @@ use dusk_bls12_381::BlsScalar;
 
 use crate::hades::{FULL_ROUNDS, PARTIAL_ROUNDS, WIDTH};
 
-const ROUNDS: usize = FULL_ROUNDS + PARTIAL_ROUNDS;
+pub(crate) const ROUNDS: usize = FULL_ROUNDS + PARTIAL_ROUNDS;
 
 /// `ROUND_CONSTANTS` consists on a static reference that points to the
 /// pre-loaded 340 constant scalar of the bls12_381 curve.

--- a/src/hash/gadget.rs
+++ b/src/hash/gadget.rs
@@ -9,10 +9,9 @@ use alloc::vec::Vec;
 use dusk_plonk::prelude::{Composer, Witness};
 use dusk_safe::Sponge;
 
+use super::io_pattern;
 use crate::Domain;
 use crate::hades::GadgetPermutation;
-
-use super::io_pattern;
 
 /// Hash struct.
 pub struct HashGadget<'a> {

--- a/tests/encryption_gadget.rs
+++ b/tests/encryption_gadget.rs
@@ -9,8 +9,7 @@
 
 use dusk_bls12_381::BlsScalar;
 use dusk_jubjub::{GENERATOR_EXTENDED, JubJubAffine, JubJubScalar};
-use dusk_plonk::prelude::Error as PlonkError;
-use dusk_plonk::prelude::*;
+use dusk_plonk::prelude::{Error as PlonkError, *};
 use dusk_poseidon::{decrypt_gadget, encrypt, encrypt_gadget};
 use ff::Field;
 use once_cell::sync::Lazy;

--- a/tests/hash.rs
+++ b/tests/hash.rs
@@ -6,14 +6,12 @@
 
 #![cfg(feature = "zk")]
 
+use dusk_plonk::prelude::{Error as PlonkError, *};
+use dusk_poseidon::{Domain, Hash, HashGadget};
+use ff::Field;
 use once_cell::sync::Lazy;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
-
-use dusk_plonk::prelude::Error as PlonkError;
-use dusk_plonk::prelude::*;
-use dusk_poseidon::{Domain, Hash, HashGadget};
-use ff::Field;
 
 static PUB_PARAMS: Lazy<PublicParameters> = Lazy::new(|| {
     let mut rng = StdRng::seed_from_u64(0xbeef);


### PR DESCRIPTION
## Summary

Add Makefile, update CI to use inline `make` targets on `core` runners with `dsherret/rust-toolchain-file@v1`, add a `no-std` bare-metal CI job, update `rustfmt.toml` with import grouping and field shorthand, reformat code, create `AGENTS.md` with full project documentation, and replace `CLAUDE.md` with a symlink to it.