### PR TITLE
Amend release version, 0.42.0 to 0.43.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.42.0] - 2026-06-02
+## [0.43.0] - 2026-06-03
 
 ### Changed
 
@@ -574,8 +574,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#112]: https://github.com/dusk-network/poseidon252/issues/112
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/poseidon252/compare/v0.42.0...HEAD
-[0.42.0]: https://github.com/dusk-network/poseidon252/compare/v0.41.0...v0.42.0
+[Unreleased]: https://github.com/dusk-network/poseidon252/compare/v0.43.0...HEAD
+[0.43.0]: https://github.com/dusk-network/poseidon252/compare/v0.41.0...v0.43.0
 [0.41.0]: https://github.com/dusk-network/poseidon252/compare/v0.40.0...v0.41.0
 [0.40.0]: https://github.com/dusk-network/poseidon252/compare/v0.39.0...v0.40.0
 [0.39.0]: https://github.com/dusk-network/poseidon252/compare/v0.38.0...v0.39.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-poseidon"
-version = "0.42.0"
+version = "0.43.0"
 description = "Implementation of Poseidon hash algorithm over the Bls12-381 Scalar field."
 categories = ["algorithms", "cryptography", "no-std", "wasm"]
 keywords = ["cryptography", "zero-knowledge", "crypto"]


### PR DESCRIPTION
This PR's purpose is to revert version 0.42.0. That one will be yanked in crates.io, and replaced by 0.43.0.

### Changed

- Set MSRV to 1.85, Rust edition 2024, and switch to stable toolchain [#274]
- Update `dusk-plonk` to `0.23` and use `dusk-curves` `0.2`
- Expose selectable `bls-backend-dusk` and `bls-backend-blst` features