### PR TITLE
Revert dusk-curves integration

### DIFF
--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -32,4 +32,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dsherret/rust-toolchain-file@v1
       - uses: Swatinem/rust-cache@v2
-      - run: cargo bench --no-default-features --features=zk,encryption,bls-backend-blst --no-run
+      - run: cargo bench --all-features --no-run

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,6 @@ Run `make help` for the full target list.
 
 - `zk` — PLONK circuit gadgets (gates `dusk-plonk`)
 - `encryption` — encrypt/decrypt module (gates `dusk-safe/encryption`)
-- `bls-backend-dusk` / `bls-backend-blst` — forwarded BLS backend
-  selection for `dusk-curves` and `dusk-plonk`; select exactly one
 
 ## Elevated Care Zones
 
@@ -55,9 +53,7 @@ and on-chain encryption.
 
 - `no_std` with `alloc` — do not add `std` dependencies
 - **Always use `--release` for tests** — the `zk` feature pulls in
-  `dusk-plonk`, which is extremely slow in debug mode. Local test commands
-  use `bls-backend-blst` explicitly; do not use `--all-features` because the
-  BLS backends are mutually exclusive.
+  `dusk-plonk`, which is extremely slow in debug mode
 - No `unwrap()`/`expect()` outside of tests — return errors instead
 - No `#[allow(...)]` lint suppression — fix the underlying issue
 - Run `make fmt` before committing (requires nightly toolchain)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.43.0] - 2026-06-03
+## [0.42.0] - 2026-06-02
 
 ### Changed
 
@@ -574,8 +574,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#112]: https://github.com/dusk-network/poseidon252/issues/112
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/poseidon252/compare/v0.43.0...HEAD
-[0.43.0]: https://github.com/dusk-network/poseidon252/compare/v0.41.0...v0.43.0
+[Unreleased]: https://github.com/dusk-network/poseidon252/compare/v0.42.0...HEAD
+[0.42.0]: https://github.com/dusk-network/poseidon252/compare/v0.41.0...v0.42.0
 [0.41.0]: https://github.com/dusk-network/poseidon252/compare/v0.40.0...v0.41.0
 [0.40.0]: https://github.com/dusk-network/poseidon252/compare/v0.39.0...v0.40.0
 [0.39.0]: https://github.com/dusk-network/poseidon252/compare/v0.38.0...v0.39.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Set MSRV to 1.85, Rust edition 2024, and switch to stable toolchain [#274]
-- Update `dusk-plonk` to `0.23` and use `dusk-curves` `0.2`
-- Expose selectable `bls-backend-dusk` and `bls-backend-blst` features
+- Update `dusk-plonk` to `0.22.0-rc.0`
 
 ## [0.41.0] - 2025-02-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.42.0] - 2026-06-02
-
 ### Changed
 
 - Set MSRV to 1.85, Rust edition 2024, and switch to stable toolchain [#274]
@@ -574,8 +572,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#112]: https://github.com/dusk-network/poseidon252/issues/112
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/poseidon252/compare/v0.42.0...HEAD
-[0.42.0]: https://github.com/dusk-network/poseidon252/compare/v0.41.0...v0.42.0
+[Unreleased]: https://github.com/dusk-network/poseidon252/compare/v0.41.0...HEAD
 [0.41.0]: https://github.com/dusk-network/poseidon252/compare/v0.40.0...v0.41.0
 [0.40.0]: https://github.com/dusk-network/poseidon252/compare/v0.39.0...v0.40.0
 [0.39.0]: https://github.com/dusk-network/poseidon252/compare/v0.38.0...v0.39.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-poseidon"
-version = "0.42.0"
+version = "0.42.0-rc.0"
 description = "Implementation of Poseidon hash algorithm over the Bls12-381 Scalar field."
 categories = ["algorithms", "cryptography", "no-std", "wasm"]
 keywords = ["cryptography", "zero-knowledge", "crypto"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,9 @@ rust-version = "1.85"
 license = "MPL-2.0"
 
 [dependencies]
-dusk-curves = { version = "0.2", default-features = false, features = ["zeroize"] }
+dusk-bls12_381 = { version = "0.14", default-features = false, features = ["zeroize"] }
 dusk-jubjub = { version = "0.15", default-features = false }
-dusk-plonk = { version = "0.23", default-features = false, features = ["alloc", "zeroize"], optional = true }
+dusk-plonk = { version = "0.22.0-rc.0", default-features = false, features = ["alloc", "zeroize"], optional = true }
 dusk-safe = "0.3"
 
 [dev-dependencies]
@@ -25,17 +25,9 @@ dusk-bytes = "0.1"
 
 [features]
 zk = [
-    "dep:dusk-plonk",
+    "dusk-plonk",
 ]
 encryption = ["dusk-safe/encryption"]
-bls-backend-dusk = [
-    "dusk-curves/bls-backend-dusk",
-    "dusk-plonk?/bls-backend-dusk",
-]
-bls-backend-blst = [
-    "dusk-curves/bls-backend-blst",
-    "dusk-plonk?/bls-backend-blst",
-]
 
 [profile.dev]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-poseidon"
-version = "0.43.0"
+version = "0.42.0"
 description = "Implementation of Poseidon hash algorithm over the Bls12-381 Scalar field."
 categories = ["algorithms", "cryptography", "no-std", "wasm"]
 keywords = ["cryptography", "zero-knowledge", "crypto"]

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,13 @@
-BLS_BACKEND ?= bls-backend-blst
-NOSTD_BLS_BACKEND ?= bls-backend-dusk
-FEATURES := zk,encryption,$(BLS_BACKEND)
-
 help: ## Display this help screen
 	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-test: ## Run tests (release mode, BLST backend by default)
-	@cargo test --features=$(FEATURES) --release
-	@cargo test --features=encryption,$(BLS_BACKEND) --release --no-run
+test: ## Run tests (--all-features, release mode)
+	@cargo test --all-features --release
+	@cargo test --features=encryption --no-run
 
 clippy: ## Run clippy
-	@cargo clippy --features=$(FEATURES) -- -D warnings
-	@cargo clippy --no-default-features --features=$(BLS_BACKEND) -- -D warnings
+	@cargo clippy --all-features -- -D warnings
+	@cargo clippy --no-default-features -- -D warnings
 
 cq: ## Run code quality checks (formatting + clippy)
 	@$(MAKE) fmt CHECK=1
@@ -22,16 +18,16 @@ fmt: ## Format code
 	@cargo +nightly fmt --all $(if $(CHECK),-- --check,)
 
 check: ## Type-check
-	@cargo check --features=$(FEATURES)
+	@cargo check --all-features
 
 doc: ## Generate docs
-	@cargo doc --no-deps --features=$(FEATURES)
+	@cargo doc --no-deps --all-features
 
 clean: ## Clean build artifacts
 	@cargo clean
 
 no-std: ## Verify no_std bare-metal build
 	@rustup target add thumbv6m-none-eabi 2>/dev/null || true
-	@cargo build --release --no-default-features --features=$(NOSTD_BLS_BACKEND) --target thumbv6m-none-eabi
+	@cargo build --release --no-default-features --target thumbv6m-none-eabi
 
 .PHONY: help test clippy cq fmt check doc clean no-std

--- a/README.md
+++ b/README.md
@@ -17,17 +17,6 @@ The library provides the two hashing techniques of Poseidon:
 - The 'normal' hashing functionalities operating on `BlsScalar`.
 - The 'gadget' hashing functionalities that build a circuit which outputs the hash.
 
-## Features
-
-Select exactly one BLS backend feature when depending on this crate:
-
-- `bls-backend-dusk` forwards the pure Rust Dusk backend.
-- `bls-backend-blst` forwards the `blst` backend.
-
-The backend features are mutually exclusive and are not enabled by default.
-The `zk` feature enables the `dusk-plonk` gadgets, and `encryption` enables
-the SAFE encryption helpers.
-
 ## Example
 
 ```rust
@@ -35,7 +24,7 @@ use rand::rngs::StdRng;
 use rand::SeedableRng;
 
 use dusk_poseidon::{Domain, Hash};
-use dusk_curves::bls12_381::BlsScalar;
+use dusk_bls12_381::BlsScalar;
 use ff::Field;
 
 // generate random input
@@ -67,7 +56,7 @@ There are benchmarks for hashing, encrypting and decrypting in their native form
 
 To run all benchmarks on your machine, run
 ```shell
-cargo bench --features=zk,encryption,bls-backend-blst
+cargo bench --features=zk,encryption
 ```
 in the repository.
 

--- a/assets/HOWTO.md
+++ b/assets/HOWTO.md
@@ -11,7 +11,7 @@ The `arc.bin` and `mds.bin` files in this folder are generated using the snippet
 ## Generate round constants
 
 ```rust
-use dusk_curves::bls12_381::BlsScalar;
+use dusk_bls12_381::BlsScalar;
 use sha2::{Digest, Sha512};
 use std::fs;
 use std::io::Write;
@@ -59,7 +59,7 @@ fn write_constants() -> std::io::Result<()> {
 ## Generate mds matrix
 
 ```rust
-use dusk_curves::bls12_381::BlsScalar;
+use dusk_bls12_381::BlsScalar;
 use std::fs;
 use std::io::Write;
 

--- a/benches/decrypt.rs
+++ b/benches/decrypt.rs
@@ -5,7 +5,7 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
-use dusk_curves::bls12_381::BlsScalar;
+use dusk_bls12_381::BlsScalar;
 use dusk_jubjub::{GENERATOR_EXTENDED, JubJubAffine, JubJubScalar};
 use dusk_plonk::prelude::{Error as PlonkError, *};
 use dusk_poseidon::{decrypt, decrypt_gadget, encrypt};

--- a/benches/encrypt.rs
+++ b/benches/encrypt.rs
@@ -5,7 +5,7 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
-use dusk_curves::bls12_381::BlsScalar;
+use dusk_bls12_381::BlsScalar;
 use dusk_jubjub::{GENERATOR_EXTENDED, JubJubAffine, JubJubScalar};
 use dusk_plonk::prelude::{Error as PlonkError, *};
 use dusk_poseidon::{encrypt, encrypt_gadget};

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -11,7 +11,7 @@
 //! ```rust
 //! #![cfg(feature = "encryption")]
 //!
-//! use dusk_curves::bls12_381::BlsScalar;
+//! use dusk_bls12_381::BlsScalar;
 //! use dusk_jubjub::{JubJubScalar, GENERATOR_EXTENDED, dhke};
 //! use dusk_poseidon::{decrypt, encrypt, Error};
 //! use ff::Field;
@@ -47,7 +47,7 @@ pub(crate) mod gadget;
 
 use alloc::vec::Vec;
 
-use dusk_curves::bls12_381::BlsScalar;
+use dusk_bls12_381::BlsScalar;
 use dusk_jubjub::JubJubAffine;
 
 use crate::hades::ScalarPermutation;

--- a/src/hades.rs
+++ b/src/hades.rs
@@ -58,8 +58,8 @@ mod tests {
     extern crate std;
     use std::{format, vec};
 
+    use dusk_bls12_381::BlsScalar;
     use dusk_bytes::ParseHexStr;
-    use dusk_curves::bls12_381::BlsScalar;
     use dusk_safe::{Call, Safe, Sponge};
 
     use crate::hades::{ScalarPermutation, WIDTH};

--- a/src/hades/mds_matrix.rs
+++ b/src/hades/mds_matrix.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use dusk_curves::bls12_381::BlsScalar;
+use dusk_bls12_381::BlsScalar;
 
 use crate::hades::WIDTH;
 

--- a/src/hades/permutation/gadget.rs
+++ b/src/hades/permutation/gadget.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use dusk_curves::bls12_381::BlsScalar;
+use dusk_bls12_381::BlsScalar;
 use dusk_plonk::prelude::*;
 use dusk_safe::Safe;
 

--- a/src/hades/permutation/scalar.rs
+++ b/src/hades/permutation/scalar.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use dusk_curves::bls12_381::BlsScalar;
+use dusk_bls12_381::BlsScalar;
 use dusk_safe::Safe;
 
 use super::Hades;

--- a/src/hades/round_constants.rs
+++ b/src/hades/round_constants.rs
@@ -11,7 +11,7 @@
 //! https://extgit.iaik.tugraz.at/krypto/hadesmimc/blob/master/code/calc_round_numbers.py
 //! and then mapped onto `BlsScalar` in the Bls12_381 scalar field.
 
-use dusk_curves::bls12_381::BlsScalar;
+use dusk_bls12_381::BlsScalar;
 
 use crate::hades::{FULL_ROUNDS, PARTIAL_ROUNDS, WIDTH};
 

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -6,7 +6,7 @@
 
 use alloc::vec::Vec;
 
-use dusk_curves::bls12_381::BlsScalar;
+use dusk_bls12_381::BlsScalar;
 use dusk_jubjub::JubJubScalar;
 use dusk_safe::{Call, Sponge};
 

--- a/tests/encryption.rs
+++ b/tests/encryption.rs
@@ -6,7 +6,7 @@
 
 #![cfg(feature = "encryption")]
 
-use dusk_curves::bls12_381::BlsScalar;
+use dusk_bls12_381::BlsScalar;
 use dusk_jubjub::{GENERATOR_EXTENDED, JubJubAffine, JubJubScalar};
 use dusk_poseidon::{Error, decrypt, encrypt};
 use ff::Field;

--- a/tests/encryption_gadget.rs
+++ b/tests/encryption_gadget.rs
@@ -7,7 +7,7 @@
 #![cfg(feature = "encryption")]
 #![cfg(feature = "zk")]
 
-use dusk_curves::bls12_381::BlsScalar;
+use dusk_bls12_381::BlsScalar;
 use dusk_jubjub::{GENERATOR_EXTENDED, JubJubAffine, JubJubScalar};
 use dusk_plonk::prelude::{Error as PlonkError, *};
 use dusk_poseidon::{decrypt_gadget, encrypt, encrypt_gadget};


### PR DESCRIPTION
## Summary

Reverts the `dusk-curves` migration (#278) and the two releases published on
top of it (#279 `0.42.0`, #280 `0.43.0`). Those releases were withdrawn from
crates.io, but the code remained on `master`, forcing upcoming work onto a
diverged mainline. This returns `master` to its pre-curves state: `BlsScalar`
is supplied by `dusk-bls12_381` again, `dusk-plonk` is back on `0.22`, and the
`bls-backend-dusk`/`bls-backend-blst` features are removed.

Source revert only — no version bump, no publish. The tree is byte-identical to
the pre-curves commit `36993ec`.
