### PR TITLE
Reject invalid encryption shared secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Reject invalid shared secrets in encryption and decryption [#284]
 - Reduce the Poseidon ZK gadget constraint count while preserving existing hash outputs [#281]
 - Set MSRV to 1.85, Rust edition 2024, and switch to stable toolchain [#274]
 - Update `dusk-plonk` to `0.22.0-rc.0`
@@ -528,6 +529,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Variants of sponge for `Scalar` & `Gadget(Variable/LC)`.
 
 <!-- ISSUES -->
+[#284]: https://github.com/dusk-network/Poseidon252/issues/284
 [#281]: https://github.com/dusk-network/Poseidon252/issues/281
 [#274]: https://github.com/dusk-network/poseidon252/issues/274
 [#260]: https://github.com/dusk-network/poseidon252/issues/260

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -56,7 +56,16 @@ use crate::{Domain, Error};
 /// This function encrypts a given message with a shared secret point on the
 /// jubjub-curve and a bls-scalar nonce using the poseidon hash function.
 ///
-/// The shared secret is expected to be a valid point on the jubjub-curve.
+/// The shared secret must be a non-identity point in the prime-order subgroup
+/// of the jubjub curve.
+/// Invalid shared secrets return [`Error::InvalidPoint`]. This validation costs
+/// one jubjub scalar multiplication per call.
+///
+/// This check does not make DHKE with an unchecked peer point safe. Callers
+/// must validate untrusted peer public points as on-curve, non-identity, and
+/// prime-order before scalar multiplication. Protocol-facing code should not
+/// expose [`Error::InvalidPoint`] separately from authentication or decryption
+/// failures.
 ///
 /// The cipher-text will always yield exactly one element more than the message.
 pub fn encrypt(
@@ -64,6 +73,8 @@ pub fn encrypt(
     shared_secret: &JubJubAffine,
     nonce: &BlsScalar,
 ) -> Result<Vec<BlsScalar>, Error> {
+    validate_shared_secret(shared_secret)?;
+
     Ok(dusk_safe::encrypt(
         ScalarPermutation::new(),
         Domain::Encryption,
@@ -77,7 +88,16 @@ pub fn encrypt(
 /// secret point on the jubjub-curve and a bls-scalar nonce using the poseidon
 /// hash function.
 ///
-/// The shared secret is expected to be a valid point on the jubjub-curve.
+/// The shared secret must be a non-identity point in the prime-order subgroup
+/// of the jubjub curve.
+/// Invalid shared secrets return [`Error::InvalidPoint`]. This validation costs
+/// one jubjub scalar multiplication per call.
+///
+/// This check does not make DHKE with an unchecked peer point safe. Callers
+/// must validate untrusted peer public points as on-curve, non-identity, and
+/// prime-order before scalar multiplication. Protocol-facing code should not
+/// expose [`Error::InvalidPoint`] separately from authentication or decryption
+/// failures.
 ///
 /// The cipher-text will always yield exactly one element more than the message.
 pub fn decrypt(
@@ -85,6 +105,8 @@ pub fn decrypt(
     shared_secret: &JubJubAffine,
     nonce: &BlsScalar,
 ) -> Result<Vec<BlsScalar>, Error> {
+    validate_shared_secret(shared_secret)?;
+
     Ok(dusk_safe::decrypt(
         ScalarPermutation::new(),
         Domain::Encryption,
@@ -92,4 +114,16 @@ pub fn decrypt(
         &[shared_secret.get_u(), shared_secret.get_v()],
         nonce,
     )?)
+}
+
+fn validate_shared_secret(shared_secret: &JubJubAffine) -> Result<(), Error> {
+    if !bool::from(shared_secret.is_on_curve()) {
+        return Err(Error::InvalidPoint);
+    }
+
+    if !bool::from(shared_secret.is_prime_order()) {
+        return Err(Error::InvalidPoint);
+    }
+
+    Ok(())
 }

--- a/src/encryption/gadget.rs
+++ b/src/encryption/gadget.rs
@@ -14,7 +14,9 @@ use crate::{Domain, Error};
 /// This function encrypts a given message with a shared secret point on the
 /// jubjub-curve and a bls-scalar nonce using the poseidon hash function.
 ///
-/// The shared secret is expected to be a valid point on the jubjub-curve.
+/// The caller must constrain the shared secret to a non-identity point in the
+/// prime-order subgroup of the jubjub curve. This gadget only consumes its
+/// coordinate witnesses.
 ///
 /// The cipher-text will always yield exactly one element more than the message.
 pub fn encrypt_gadget(
@@ -36,7 +38,9 @@ pub fn encrypt_gadget(
 /// secret point on the jubjub-curve and a bls-scalar nonce using the poseidon
 /// hash function.
 ///
-/// The shared secret is expected to be a valid point on the jubjub-curve.
+/// The caller must constrain the shared secret to a non-identity point in the
+/// prime-order subgroup of the jubjub curve. This gadget only consumes its
+/// coordinate witnesses.
 ///
 /// The cipher-text will always yield exactly one element more than the message.
 pub fn decrypt_gadget(

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,7 +27,7 @@ pub enum Error {
     /// and nonce.
     DecryptionFailed,
 
-    /// Invalid point on the jubjub-curve
+    /// Invalid shared-secret point on the jubjub curve.
     InvalidPoint,
 }
 

--- a/tests/encryption.rs
+++ b/tests/encryption.rs
@@ -45,6 +45,44 @@ fn encrypt_decrypt() -> Result<(), Error> {
 }
 
 #[test]
+fn non_prime_order_shared_secrets_fail() {
+    let message = [BlsScalar::from(42)];
+    let cipher = [BlsScalar::from(1), BlsScalar::from(2)];
+    let nonce = BlsScalar::from(3);
+    let identity = JubJubAffine::identity();
+    let low_order =
+        JubJubAffine::from_raw_unchecked(BlsScalar::zero(), -BlsScalar::one());
+    let off_curve =
+        JubJubAffine::from_raw_unchecked(BlsScalar::zero(), BlsScalar::zero());
+    let mixed_order = JubJubAffine::from(GENERATOR_EXTENDED + low_order);
+
+    assert!(bool::from(identity.is_on_curve()));
+    assert!(bool::from(identity.is_torsion_free()));
+    assert!(bool::from(identity.is_identity()));
+    assert!(bool::from(low_order.is_on_curve()));
+    assert!(!bool::from(low_order.is_torsion_free()));
+    assert!(!bool::from(low_order.is_identity()));
+    assert!(!bool::from(off_curve.is_on_curve()));
+    assert!(bool::from(mixed_order.is_on_curve()));
+    assert!(!bool::from(mixed_order.is_torsion_free()));
+    assert!(!bool::from(mixed_order.is_identity()));
+    assert!(!bool::from(mixed_order.is_small_order()));
+
+    let invalid_secrets = [identity, low_order, off_curve, mixed_order];
+
+    for shared_secret in invalid_secrets {
+        assert_eq!(
+            encrypt(message, &shared_secret, &nonce).unwrap_err(),
+            Error::InvalidPoint
+        );
+        assert_eq!(
+            decrypt(cipher, &shared_secret, &nonce).unwrap_err(),
+            Error::InvalidPoint
+        );
+    }
+}
+
+#[test]
 fn incorrect_shared_secret_fails() -> Result<(), Error> {
     let mut rng = StdRng::seed_from_u64(0x42424242);
     let message_len = 21usize;


### PR DESCRIPTION
## Summary

- reject identity, off-curve, pure low-order, and mixed-order shared secrets in native encryption and decryption
- return the existing `Error::InvalidPoint` before invoking SAFE
- document the membership obligation for gadget callers without changing circuit layouts
- add regressions that distinguish identity, pure low-order, and mixed-order points

## Rationale

Using an identity or non-prime-order DHKE result as encryption material weakens the intended shared-secret boundary. A small-order-only check is insufficient: an on-curve mixed-order point can be non-identity and not itself small-order while still failing subgroup membership.

This is preventive public-library hardening. Current Rusk and Phoenix revisions have no callers of these native Poseidon encryption APIs; Phoenix note encryption feeds its DHKE result to AES instead.

## Compatibility and performance

Valid prime-order inputs reach the unchanged SAFE implementation with identical coordinates and nonce. Gadget constraints are intentionally unchanged because adding point-membership constraints would alter circuit layouts and verifier keys.

Complete subgroup validation adds approximately 75 microseconds per call on the test machine. For two-scalar messages, native encryption measured about 43 to 117 microseconds and decryption about 39 to 116 microseconds. The cheaper on-curve/non-small-order predicate was rejected because it accepts mixed-order points.

## Validation

- `make fmt CHECK=1`
- `make clippy`
- `make test`
- `make check`
- `make doc`
- `make no-std`
- `cargo bench --all-features --no-run`
- mutation controls for unconditional acceptance and the incomplete small-order predicate

Closes #284
