### PR TITLE
Use LazyLock for test public parameters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ dusk-safe = "0.3"
 criterion = "0.5"
 rand = { version = "0.8", default-features = false, features = ["getrandom", "std_rng"] }
 ff = { version = "0.13", default-features = false }
-once_cell = "1"
 dusk-bytes = "0.1"
 
 [features]

--- a/benches/decrypt.rs
+++ b/benches/decrypt.rs
@@ -4,19 +4,20 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+use std::sync::LazyLock;
+
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use dusk_bls12_381::BlsScalar;
 use dusk_jubjub::{GENERATOR_EXTENDED, JubJubAffine, JubJubScalar};
 use dusk_plonk::prelude::{Error as PlonkError, *};
 use dusk_poseidon::{decrypt, decrypt_gadget, encrypt};
 use ff::Field;
-use once_cell::sync::Lazy;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 
 const MESSAGE_LEN: usize = 2;
 
-static PUB_PARAMS: Lazy<PublicParameters> = Lazy::new(|| {
+static PUB_PARAMS: LazyLock<PublicParameters> = LazyLock::new(|| {
     let mut rng = StdRng::seed_from_u64(0xfab);
 
     const CAPACITY: usize = 11;

--- a/benches/encrypt.rs
+++ b/benches/encrypt.rs
@@ -4,19 +4,20 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+use std::sync::LazyLock;
+
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use dusk_bls12_381::BlsScalar;
 use dusk_jubjub::{GENERATOR_EXTENDED, JubJubAffine, JubJubScalar};
 use dusk_plonk::prelude::{Error as PlonkError, *};
 use dusk_poseidon::{encrypt, encrypt_gadget};
 use ff::Field;
-use once_cell::sync::Lazy;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 
 const MESSAGE_LEN: usize = 2;
 
-static PUB_PARAMS: Lazy<PublicParameters> = Lazy::new(|| {
+static PUB_PARAMS: LazyLock<PublicParameters> = LazyLock::new(|| {
     let mut rng = StdRng::seed_from_u64(0xfab);
 
     const CAPACITY: usize = 11;

--- a/tests/encryption_gadget.rs
+++ b/tests/encryption_gadget.rs
@@ -7,16 +7,17 @@
 #![cfg(feature = "encryption")]
 #![cfg(feature = "zk")]
 
+use std::sync::LazyLock;
+
 use dusk_bls12_381::BlsScalar;
 use dusk_jubjub::{GENERATOR_EXTENDED, JubJubAffine, JubJubScalar};
 use dusk_plonk::prelude::{Error as PlonkError, *};
 use dusk_poseidon::{decrypt_gadget, encrypt, encrypt_gadget};
 use ff::Field;
-use once_cell::sync::Lazy;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 
-static PUB_PARAMS: Lazy<PublicParameters> = Lazy::new(|| {
+static PUB_PARAMS: LazyLock<PublicParameters> = LazyLock::new(|| {
     let mut rng = StdRng::seed_from_u64(0xfab);
 
     const CAPACITY: usize = 13;

--- a/tests/hash.rs
+++ b/tests/hash.rs
@@ -6,14 +6,15 @@
 
 #![cfg(feature = "zk")]
 
+use std::sync::LazyLock;
+
 use dusk_plonk::prelude::{Error as PlonkError, *};
 use dusk_poseidon::{Domain, Hash, HashGadget};
 use ff::Field;
-use once_cell::sync::Lazy;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 
-static PUB_PARAMS: Lazy<PublicParameters> = Lazy::new(|| {
+static PUB_PARAMS: LazyLock<PublicParameters> = LazyLock::new(|| {
     let mut rng = StdRng::seed_from_u64(0xbeef);
 
     const CAPACITY: usize = 12;


### PR DESCRIPTION
Replace `once_cell::sync::Lazy` with `std::sync::LazyLock` in the test and benchmark setup. The crate already has an MSRV of Rust 1.85, so the standard-library type is available.

This removes the direct `once_cell` dev-dependency. It will remain in the resolved development graph through Criterion, so this is a small direct-dependency cleanup rather than a package-count reduction.