### PR TITLE
Update Criterion to 0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update Criterion to 0.8 [#289]
 - Raise the MSRV to Rust 1.96.1 [#287]
 - Reject invalid shared secrets in encryption and decryption [#284]
 - Reduce the Poseidon ZK gadget constraint count while preserving existing hash outputs [#281]
@@ -530,6 +531,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Variants of sponge for `Scalar` & `Gadget(Variable/LC)`.
 
 <!-- ISSUES -->
+[#289]: https://github.com/dusk-network/Poseidon252/issues/289
 [#287]: https://github.com/dusk-network/Poseidon252/issues/287
 [#284]: https://github.com/dusk-network/Poseidon252/issues/284
 [#281]: https://github.com/dusk-network/Poseidon252/issues/281

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ dusk-plonk = { version = "0.22.0-rc.0", default-features = false, features = ["a
 dusk-safe = "0.3"
 
 [dev-dependencies]
-criterion = "0.5"
+criterion = "0.8"
 rand = { version = "0.8", default-features = false, features = ["getrandom", "std_rng"] }
 ff = { version = "0.13", default-features = false }
 dusk-bytes = "0.1"

--- a/benches/decrypt.rs
+++ b/benches/decrypt.rs
@@ -4,9 +4,10 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+use std::hint::black_box;
 use std::sync::LazyLock;
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
 use dusk_bls12_381::BlsScalar;
 use dusk_jubjub::{GENERATOR_EXTENDED, JubJubAffine, JubJubScalar};
 use dusk_plonk::prelude::{Error as PlonkError, *};

--- a/benches/encrypt.rs
+++ b/benches/encrypt.rs
@@ -4,9 +4,10 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+use std::hint::black_box;
 use std::sync::LazyLock;
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
 use dusk_bls12_381::BlsScalar;
 use dusk_jubjub::{GENERATOR_EXTENDED, JubJubAffine, JubJubScalar};
 use dusk_plonk::prelude::{Error as PlonkError, *};

--- a/benches/hash.rs
+++ b/benches/hash.rs
@@ -4,7 +4,9 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
 use dusk_plonk::prelude::*;
 use dusk_poseidon::{Domain, HADES_WIDTH, Hash, HashGadget};
 use ff::Field;


### PR DESCRIPTION
Closes #289.

Updates Criterion to 0.8 and replaces its deprecated black_box re-export with std::hint::black_box.

Stacked on #288.