### PR TITLE
Forbid unsafe code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 #![no_std]
+#![forbid(unsafe_code)]
 #![doc = include_str!("../README.md")]
 #![deny(missing_docs)]
 


### PR DESCRIPTION
This PR adds `#![forbid(unsafe_code)]` at the crate root.

Unsafe Rust is not currently used. This ensures it cannot be introduced anywhere in the crate without causing a compile-time error.
